### PR TITLE
Credits Roll EndingSplit Cinematic_Ending

### DIFF
--- a/examples/splits.json
+++ b/examples/splits.json
@@ -10,6 +10,11 @@
     "tooltip": "Splits when starting a new save file"
   },
   {
+    "description": "Credits Roll (Ending)",
+    "key": "EndingSplit",
+    "tooltip": "Splits on any credits rolling, any ending"
+  },
+  {
     "description": "Main Menu (Menu)",
     "key": "Menu",
     "tooltip": "Splits on the main menu"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ fn default_splits_init() -> asr::settings::Map {
     }
     let l = asr::settings::List::new();
     l.push(options_str(&splits::Split::StartNewGame));
-    l.push(options_str(&splits::Split::ManualSplit));
+    l.push(options_str(&splits::Split::EndingSplit));
     loop {
         let old = asr::settings::Map::load();
         let new = old.clone();

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -25,6 +25,10 @@ pub enum Split {
     ///
     /// Splits when starting a new save file
     StartNewGame,
+    /// Credits Roll (Ending)
+    ///
+    /// Splits on any credits rolling, any ending
+    EndingSplit,
     /// Main Menu (Menu)
     ///
     /// Splits on the main menu
@@ -106,6 +110,7 @@ pub fn transition_splits(
         Split::StartNewGame => {
             should_split(OPENING_SCENES.contains(&scenes.old) && scenes.current == "Tut_01")
         }
+        Split::EndingSplit => should_split(scenes.current.starts_with("Cinematic_Ending")),
         Split::Menu => should_split(scenes.current == MENU_TITLE),
         Split::AnyTransition => should_split(
             scenes.current != scenes.old && !(is_menu(scenes.old) || is_menu(scenes.current)),


### PR DESCRIPTION
> In HK, each Ending Cutscene began with `Cinematic_Ending`... is that still true for Silksong?

> I can confirm only that true ending is scene `Cinematic_Ending_E`, but it fits the bill to be similar to HK