### PR TITLE
Don't remove cutscene time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ use ugly_widget::{
 use crate::{
     silksong_memory::{
         attach_silksong, GameManagerPointers, Memory, PlayerDataPointers, SceneStore,
-        GAME_STATE_ENTERING_LEVEL, GAME_STATE_EXITING_LEVEL, GAME_STATE_INACTIVE,
-        GAME_STATE_LOADING, GAME_STATE_MAIN_MENU, GAME_STATE_PLAYING,
+        GAME_STATE_CUTSCENE, GAME_STATE_ENTERING_LEVEL, GAME_STATE_EXITING_LEVEL,
+        GAME_STATE_INACTIVE, GAME_STATE_LOADING, GAME_STATE_MAIN_MENU, GAME_STATE_PLAYING,
         HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL, MENU_TITLE, QUIT_TO_MENU, UI_STATE_CUTSCENE,
         UI_STATE_PAUSED, UI_STATE_PLAYING,
     },
@@ -392,7 +392,9 @@ fn load_removal(state: &mut AutoSplitterState, mem: &Memory, gm: &GameManagerPoi
     let is_game_time_paused = (state.look_for_teleporting)
         || ((game_state == GAME_STATE_PLAYING || game_state == GAME_STATE_ENTERING_LEVEL)
             && ui_state != UI_STATE_PLAYING)
-        || (game_state != GAME_STATE_PLAYING && !accepting_input)
+        || (game_state != GAME_STATE_PLAYING
+            && game_state != GAME_STATE_CUTSCENE
+            && !accepting_input)
         || (game_state == GAME_STATE_EXITING_LEVEL || game_state == GAME_STATE_LOADING)
         || (hero_transition_state == HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL)
         || (ui_state != UI_STATE_PLAYING

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ use crate::{
         attach_silksong, GameManagerPointers, Memory, PlayerDataPointers, SceneStore,
         GAME_STATE_ENTERING_LEVEL, GAME_STATE_EXITING_LEVEL, GAME_STATE_INACTIVE,
         GAME_STATE_LOADING, GAME_STATE_MAIN_MENU, GAME_STATE_PLAYING,
-        HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL, MENU_TITLE, QUIT_TO_MENU, UI_STATE_PAUSED,
-        UI_STATE_PLAYING,
+        HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL, MENU_TITLE, QUIT_TO_MENU, UI_STATE_CUTSCENE,
+        UI_STATE_PAUSED, UI_STATE_PLAYING,
     },
     timer::SplitterAction,
 };
@@ -396,7 +396,10 @@ fn load_removal(state: &mut AutoSplitterState, mem: &Memory, gm: &GameManagerPoi
         || (game_state == GAME_STATE_EXITING_LEVEL || game_state == GAME_STATE_LOADING)
         || (hero_transition_state == HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL)
         || (ui_state != UI_STATE_PLAYING
-            && (loading_menu || (ui_state != UI_STATE_PAUSED && (!next_scene.is_empty())))
+            && (loading_menu
+                || (ui_state != UI_STATE_PAUSED
+                    && ui_state != UI_STATE_CUTSCENE
+                    && (!next_scene.is_empty())))
             && next_scene != scene_name);
     if is_game_time_paused {
         asr::timer::pause_game_time();

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -57,6 +57,7 @@ pub const GAME_STATE_CUTSCENE: i32 = 7;
 pub static NON_MENU_GAME_STATES: [i32; 2] = [GAME_STATE_PLAYING, GAME_STATE_CUTSCENE];
 
 // UI_STATE 1: Main Menu
+pub const UI_STATE_CUTSCENE: i32 = 3;
 pub const UI_STATE_PLAYING: i32 = 4;
 pub const UI_STATE_PAUSED: i32 = 5;
 


### PR DESCRIPTION
> So for the load remover does this remove non loading time like hk?
> Our goal with this one was to avoid that. Like if TAS runs the load remover only 1 frame should be removed each load
> Which prevents the "oh this strat's faster because our auto splitter is coded like this"

> Just looking at videos where it's used it does seem like it removes too much
> It also seems to remove cutscenes

This PR stops it from removing cutscene time: tested with the Bellbeast Travel cutscene.