### PR TITLE
SceneLoad IsActivationAllowed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,9 @@ async fn main() {
                 let _: bool = mem.deref(&gm.hazard_respawning).unwrap_or_default();
                 let _: bool = mem.deref(&gm.hero_recoil_frozen).unwrap_or_default();
                 let _: i32 = mem.deref(&gm.hero_transition_state).unwrap_or_default();
+                let _: bool = mem
+                    .deref(&gm.scene_load_activation_allowed)
+                    .unwrap_or_default();
                 let _: Address64 = mem.deref(&gm.next_scene_name).unwrap_or_default();
                 let _: Address64 = mem.deref(&gm.scene_name).unwrap_or_default();
                 let _: i32 = mem.deref(&gm.ui_state_vanilla).unwrap_or_default();
@@ -388,6 +391,9 @@ fn load_removal(state: &mut AutoSplitterState, mem: &Memory, gm: &GameManagerPoi
     // TODO: hazard_respawning
     let accepting_input: bool = mem.deref(&gm.accepting_input).unwrap_or_default();
     let hero_transition_state: i32 = mem.deref(&gm.hero_transition_state).unwrap_or_default();
+    let scene_load_activation_allowed: bool = mem
+        .deref(&gm.scene_load_activation_allowed)
+        .unwrap_or_default();
     // TODO: tile_map_dirty, uses_scene_transition_routine
 
     let is_game_time_paused = (state.look_for_teleporting)
@@ -396,7 +402,8 @@ fn load_removal(state: &mut AutoSplitterState, mem: &Memory, gm: &GameManagerPoi
         || (game_state != GAME_STATE_PLAYING
             && game_state != GAME_STATE_CUTSCENE
             && !accepting_input)
-        || (game_state == GAME_STATE_EXITING_LEVEL || game_state == GAME_STATE_LOADING)
+        || ((game_state == GAME_STATE_EXITING_LEVEL && scene_load_activation_allowed)
+            || game_state == GAME_STATE_LOADING)
         || (hero_transition_state == HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL)
         || (ui_state != UI_STATE_PLAYING
             && (loading_menu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,11 @@ impl Settings {
     }
     pub fn get_split(&self, i: u64) -> Option<splits::Split> {
         let splits = self.splits.get_list();
-        splits.get(i as usize).or_else(|| splits.last()).cloned().cloned()
+        splits
+            .get(i as usize)
+            .or_else(|| splits.last())
+            .cloned()
+            .cloned()
     }
 
     pub fn default_init_register() -> Settings {

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -178,6 +178,11 @@ declare_pointers!(GameManagerPointers {
         0,
         &["_instance", "<hero_ctrl>k__BackingField", "transitionState"],
     ),
+    scene_load_activation_allowed: UnityPointer<3> = UnityPointer::new(
+        "GameManager",
+        0,
+        &["_instance", "sceneLoad", "<IsActivationAllowed>k__BackingField"],
+    ),
 });
 
 declare_pointers!(PlayerDataPointers {
@@ -345,7 +350,12 @@ impl SceneStore {
 
     pub fn transition_now(&mut self, mem: &Memory, gm: &GameManagerPointers) -> bool {
         self.new_curr_scene_name(mem.read_string(&gm.scene_name).unwrap_or_default());
-        self.new_next_scene_name(mem.read_string(&gm.next_scene_name).unwrap_or_default());
+        if mem
+            .deref(&gm.scene_load_activation_allowed)
+            .unwrap_or_default()
+        {
+            self.new_next_scene_name(mem.read_string(&gm.next_scene_name).unwrap_or_default());
+        }
 
         if self.new_data_next {
             self.new_data_curr = false;


### PR DESCRIPTION
> So for the load remover does this remove non loading time like hk?
> Our goal with this one was to avoid that. Like if TAS runs the load remover only 1 frame should be removed each load
> Which prevents the "oh this strat's faster because our auto splitter is coded like this"

> Just looking at videos where it's used it does seem like it removes too much

This PR stops it from removing non-loading time at the beginning of scene transitions, before SceneLoad IsActivationAllowed is true.