### PR TITLE
Breakfix for DriftersCloakTrans

### DIFF
--- a/src/splits.rs
+++ b/src/splits.rs
@@ -664,7 +664,11 @@ pub fn transition_splits(
         // endregion: DeepDocks
 
         // region: FarFields
-        Split::DriftersCloakTrans => should_split(mem.deref(&pd.has_brolly).unwrap_or_default()),
+        Split::DriftersCloakTrans => should_split(
+            mem.deref(&pd.has_brolly).unwrap_or_default()
+                && scenes.old == "Bone_East_Umbrella"
+                && scenes.current == "Bone_East_09",
+        ),
         // endregion: FarFields
 
         // region: Greymoor


### PR DESCRIPTION
Quick fix for #18 

Obtaining the item hard saves in Bone_East_Umbrella, so there is no way to accidentally miss this transition.

Tested in game