### PR TITLE
fix ShermaReturned for hksm parsing

### DIFF
--- a/examples/splits.json
+++ b/examples/splits.json
@@ -895,7 +895,7 @@
   },
   {
     "alias": null,
-    "description": "Sherma Returned(NPC)",
+    "description": "Sherma Returned (NPC)",
     "key": "ShermaReturned",
     "tooltip": "Splits when Sherma is rescued and time passes"
   },

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -706,7 +706,7 @@ pub enum Split {
     ///
     /// Splits after defeating the Skull Tyrant
     SkullTyrant1,
-    /// Sherma Returned(NPC)
+    /// Sherma Returned (NPC)
     ///
     /// Splits when Sherma is rescued and time passes
     ShermaReturned,


### PR DESCRIPTION
HKSM parses out the description and category with a regular expression that expects space between the name and the parenthetical 

I didn't actually run `make json` as I don't have Make installed; I just edited the line manually