### PR TITLE
Add script_name

### DIFF
--- a/splits/testing/room_timer.lss
+++ b/splits/testing/room_timer.lss
@@ -29,6 +29,7 @@
     <Version>1.0.0.0</Version>
     <ScriptPath />
     <CustomSettings>
+      <Setting id="script_name" type="string" value="silksong_autosplit_wasm" />
       <Setting id="splits" type="list">
         <Setting type="string" value="AnyTransition" />
         <Setting type="string" value="AnyTransition" />

--- a/splits/testing/room_timer_asr.lsl
+++ b/splits/testing/room_timer_asr.lsl
@@ -194,6 +194,7 @@
         <Version>1.0</Version>
         <ScriptPath>C:\Users\Owner\Documents\git\LiveSplit\silksong-autosplit-wasm\target\wasm32-unknown-unknown\release\silksong_autosplit_wasm.wasm</ScriptPath>
         <CustomSettings>
+          <Setting id="script_name" type="string" value="silksong_autosplit_wasm" />
           <Setting id="splits" type="list">
             <Setting type="string" value="AnyTransition" />
             <Setting type="string" value="AnyTransition" />

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,14 @@ asr::panic_handler!();
 
 // --------------------------------------------------------
 
+static MODULE_PATH: &str = module_path!();
+
+fn this_script_name() -> &'static str {
+    MODULE_PATH
+        .split_once("::")
+        .map_or(MODULE_PATH, |(base, _)| base)
+}
+
 /// The dash symbol to use for generic dashes in text.
 pub const DASH: &str = "—";
 
@@ -324,6 +332,19 @@ impl Settings {
 
 fn default_splits_init() -> asr::settings::Map {
     let settings1 = asr::settings::Map::load();
+    let this_script = this_script_name();
+    if let Some(script_name) = settings1.get("script_name") {
+        if script_name.get_string().unwrap_or_default() != this_script {
+            asr::print_message(&format!(
+                "error: settings for wrong script_name: {:?} vs {}",
+                script_name, this_script
+            ));
+            panic!(
+                "error: settings for wrong script_name: {:?} vs {}",
+                script_name, this_script
+            );
+        }
+    }
     if settings1
         .get("splits")
         .is_some_and(|v| v.get_list().is_some_and(|l| !l.is_empty()))
@@ -341,6 +362,7 @@ fn default_splits_init() -> asr::settings::Map {
     loop {
         let old = asr::settings::Map::load();
         let new = old.clone();
+        new.insert("script_name", this_script);
         new.insert("splits", &l);
         if new.store_if_unchanged(&old) {
             asr::print_message("No settings found: default splits initialized");
@@ -353,6 +375,14 @@ fn asr_settings_normalize(m: &asr::settings::Map) -> Option<()> {
     let old_splits = m.get("splits")?.get_list()?;
     let new_splits = asr::settings::List::new();
     let mut changed = false;
+    let this_script = this_script_name();
+    if !m
+        .get("script_name")
+        .is_some_and(|v| v.get_string().unwrap_or_default() == this_script)
+    {
+        changed = true;
+        m.insert("script_name", this_script);
+    }
     for (i, old_split) in old_splits.iter().enumerate() {
         let old_string = old_split.get_string()?;
         let new_string = options_normalize::<splits::Split>(&old_string);


### PR DESCRIPTION
To avoid overwriting the settings for files which may have been produced for the Hollow Knight autosplitter, and to avoid having settings for the Silksong autosplitter overwritten by the Hollow Knight autosplitter.