### PR TITLE
Add Wanderer, Beast, Architect, Shaman crest splits.

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -227,6 +227,10 @@ declare_pointers!(PlayerDataPointers {
     unlocked_melody_lift: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "UnlockedMelodyLift"]),
     nail_upgrades: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "nailUpgrades"]),
     completed_memory_reaper: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "completedMemory_reaper"]),
+    completed_memory_wanderer: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "completedMemory_wanderer"]),
+    completed_memory_beast: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "completedMemory_beast"]),
+    completed_memory_toolmaster: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "completedMemory_toolmaster"]),
+    completed_memory_shaman: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "completedMemory_shaman"]),
 
     savedflea_ant_03: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "SavedFlea_Ant_03"]),
     savedflea_belltown_04: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "SavedFlea_Belltown_04"]),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -461,10 +461,46 @@ pub enum Split {
     // endregion: MaskShards
 
     // region: Crests
+    /// Reaper Crest (Crest)
+    ///
+    /// Splits when the Reaper Crest is unlocked
+    ReaperCrest,
     /// Reaper Crest (Transition)
     ///
     /// Splits when leaving the church with the Reaper Crest unlocked
     ReaperCrestTrans,
+    /// Wanderer Crest (Crest)
+    ///
+    /// Splits when the Wanderer Crest is unlocked
+    WandererCrest,
+    /// Wanderer Crest (Transition)
+    ///
+    /// Splits when leaving the chapel with the Wanderer Crest unlocked
+    WandererCrestTrans,
+    /// Beast Crest (Crest)
+    ///
+    /// Splits when the Beast Crest is unlocked
+    BeastCrest,
+    /// Beast Crest (Transition)
+    ///
+    /// Splits when leaving the room with the Beast Crest unlocked
+    BeastCrestTrans,
+    /// Architect Crest (Crest)
+    ///
+    /// Splits when the Architect Crest is unlocked
+    ArchitectCrest,
+    /// Architect Crest (Transition)
+    ///
+    /// Splits when leaving the room with the Architect Crest unlocked
+    ArchitectCrestTrans,
+    /// Shaman Crest (Crest)
+    ///
+    /// Splits when the Shaman Crest is unlocked
+    ShamanCrest,
+    /// Shaman Crest (Transition)
+    ///
+    /// Splits when leaving the room with the Shaman Crest unlocked
+    ShamanCrestTrans,
     // endregion: Crests
 
     // region: FleaSpecific
@@ -1078,6 +1114,19 @@ pub fn transition_splits(
         Split::ReaperCrestTrans => {
             should_split(mem.deref(&pd.completed_memory_reaper).unwrap_or_default())
         }
+        Split::WandererCrestTrans => {
+            should_split(mem.deref(&pd.completed_memory_wanderer).unwrap_or_default())
+        }
+        Split::BeastCrestTrans => {
+            should_split(mem.deref(&pd.completed_memory_beast).unwrap_or_default())
+        }
+        Split::ArchitectCrestTrans => should_split(
+            mem.deref(&pd.completed_memory_toolmaster)
+                .unwrap_or_default(),
+        ),
+        Split::ShamanCrestTrans => {
+            should_split(mem.deref(&pd.completed_memory_shaman).unwrap_or_default())
+        }
         // endregion: Crests
 
         // region: MiscTE
@@ -1335,8 +1384,21 @@ pub fn continuous_splits(
         // endregion: MaskShards
 
         // region: Crests
-        Split::ReaperCrestTrans => {
+        Split::ReaperCrest => {
             should_split(mem.deref(&pd.completed_memory_reaper).unwrap_or_default())
+        }
+        Split::WandererCrest => {
+            should_split(mem.deref(&pd.completed_memory_wanderer).unwrap_or_default())
+        }
+        Split::BeastCrest => {
+            should_split(mem.deref(&pd.completed_memory_beast).unwrap_or_default())
+        }
+        Split::ArchitectCrest => should_split(
+            mem.deref(&pd.completed_memory_toolmaster)
+                .unwrap_or_default(),
+        ),
+        Split::ShamanCrest => {
+            should_split(mem.deref(&pd.completed_memory_shaman).unwrap_or_default())
         }
         // endregion: Crests
 


### PR DESCRIPTION
Reaper had the transition split implemented in the continuous section - changed to be a normal continuous split.

The witch crest appears to split when the cursed crest is obtained, so the logic to determine if the "proper" witch crest is obtained will require more work & be done in a follow-up.