### PR TITLE
Add Enter Citadel Front Gate transition split

### DIFF
--- a/src/splits.rs
+++ b/src/splits.rs
@@ -251,6 +251,10 @@ pub enum Split {
     ///
     /// Splits when killing Last Judge
     LastJudge,
+    /// Enter Citadel Front Gate (Transition)
+    ///
+    /// Splits when entering the Citadel past the Last Judge arena
+    EnterCitadelFrontGate,
     // endregion: BlastedSteps
 
     // region: SinnersRoad
@@ -1285,6 +1289,9 @@ pub fn transition_splits(
         }
         Split::EnterLastJudge => {
             should_split(scenes.old == "Coral_32" && scenes.current == "Coral_Judge_Arena")
+        }
+        Split::EnterCitadelFrontGate => {
+            should_split(scenes.old == "Coral_Judge_Arena" && scenes.current == "Coral_10")
         }
         // endregion: BlastedSteps
 


### PR DESCRIPTION
Request from glitch runners, as they currently skip the act 2 trigger despite entering the Citadel through this transition. I imagine plenty of categories will have a reason to go through the Citadel front gate again at some point, anyways.