### PR TITLE
Fix Ward Key split, adjust Enter Sinner's Road split

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -404,7 +404,7 @@ declare_pointers!(PlayerDataPointers {
     defeated_bone_flyer_giant_golem_scene: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "defeatedBoneFlyerGiantGolemScene"]),
     caravan_troupe_location: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "CaravanTroupeLocation"]),
     belltown_relic_dealer_gave_relic: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "BelltownRelicDealerGaveRelic"]),
-    collected_ward_key: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "CollectedWardKey"]),
+    collected_ward_key: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "collectedWardKey"]),
     belltown_greeter_met_time_passed: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "BelltownGreeterMetTimePassed"]),
     bell_shrine_enclave: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "bellShrineEnclave"]),
     defeated_zap_core_enemy: UnityPointer<3> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "defeatedZapCoreEnemy"]),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1446,9 +1446,11 @@ pub fn transition_splits(
         // endregion: BlastedSteps
 
         // region: SinnersRoad
-        Split::EnterSinnersRoad => {
-            should_split(scenes.old == "Greymoor_03" && scenes.current == "Dust_01")
-        }
+        Split::EnterSinnersRoad => should_split(
+            (scenes.old == "Greymoor_03" && scenes.current == "Dust_01")
+                || (scenes.old == "Dust_Maze_08_completed" && scenes.current == "Dust_05")
+                || (scenes.old == "Shadow_05" && scenes.current == "Dust_06"),
+        ),
         // endregion: SinnersRoad
 
         // region: TheMist


### PR DESCRIPTION
Both bug reported recently. Surprised Ward Key hadn't been caught earlier. Both new Sinner's transitions trigger area text.