### PR TITLE
Mark panic_handler! macro invocation as not(wasi)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 asr::async_main!(stable);
+#[cfg(target_os = "unknown")]
 asr::panic_handler!();
 
 // --------------------------------------------------------


### PR DESCRIPTION
ASR provides a replacement for the standard library's Instant under time_util::Instant. This requires a WASI target. When targeting WASI, the default panic handler implementation conflicts. I don't intend to make any features that actually require WASI in the main branch, but it's useful for ad-hoc time measuring, and this means I don't need to comment out the panic handler line when switching to WASI and uncomment it when removing the timestamp code.