### PR TITLE
Exclude bellway travel as a discontinuity

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -34,7 +34,8 @@ pub static DEATH_RESPAWN_MARKER_INIT: &str = "Death Respawn Marker Init";
 
 // static NON_PLAY_SCENES: [&str; 5] = [PRE_MENU_INTRO, MENU_TITLE, QUIT_TO_MENU, OPENING_SEQUENCE, PERMA_DEATH];
 
-static DEBUG_SAVE_STATE_SCENE_NAMES: [&str; 1] = ["Demo Start"];
+pub const CINEMATIC_STAG_TRAVEL: &str = "Cinematic_Stag_travel";
+static DISCONTINUITY_SCENE_NAMES: [&str; 2] = ["Demo Start", CINEMATIC_STAG_TRAVEL];
 
 static BAD_SCENE_NAMES: [&str; 11] = [
     "Untagged",
@@ -141,8 +142,8 @@ pub fn is_menu(s: &str) -> bool {
     s.is_empty() || s == MENU_TITLE || s == QUIT_TO_MENU || s == PERMA_DEATH
 }
 
-pub fn is_debug_save_state_scene(s: &str) -> bool {
-    DEBUG_SAVE_STATE_SCENE_NAMES.contains(&s)
+pub fn is_discontinuity_scene(s: &str) -> bool {
+    DISCONTINUITY_SCENE_NAMES.contains(&s)
 }
 
 // --------------------------------------------------------

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -7,8 +7,9 @@ use ugly_widget::{
 
 use crate::{
     silksong_memory::{
-        get_health, is_debug_save_state_scene, is_menu, Env, SceneStore, DEATH_RESPAWN_MARKER_INIT,
-        GAME_STATE_PLAYING, MENU_TITLE, NON_MENU_GAME_STATES, OPENING_SCENES,
+        get_health, is_discontinuity_scene, is_menu, Env, SceneStore, CINEMATIC_STAG_TRAVEL,
+        DEATH_RESPAWN_MARKER_INIT, GAME_STATE_PLAYING, MENU_TITLE, NON_MENU_GAME_STATES,
+        OPENING_SCENES,
     },
     store::Store,
     timer::{should_split, SplitterAction},
@@ -56,7 +57,7 @@ pub enum Split {
     /// Transition excluding discontinuities (Transition)
     ///
     /// Splits when entering a transition
-    /// (excludes discontinuities including save states and deaths)
+    /// (excludes discontinuities including save states, deaths, and bellway travel)
     TransitionExcludingDiscontinuities,
     // endregion: Start, End, and Menu
 
@@ -1495,8 +1496,8 @@ pub fn transition_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> Splitte
         // TODO: if there's anything like DreamGate in Silksong,
         // should TransitionExcludingDiscontinuities exclude that too?
         Split::TransitionExcludingDiscontinuities => should_split(
-            !(is_debug_save_state_scene(scenes.old)
-                || is_debug_save_state_scene(scenes.current)
+            !(is_discontinuity_scene(scenes.old)
+                || is_discontinuity_scene(scenes.current)
                 || mem.deref(&pd.health).is_ok_and(|h: i32| h == 0)),
         ),
         // endregion: Start, End, and Menu
@@ -1821,7 +1822,7 @@ pub fn transition_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> Splitte
 
         // region: Bellways
         Split::BellwayTrans => should_split(
-            scenes.old == "Cinematic_Stag_travel" && scenes.current != "Cinematic_Stag_travel",
+            scenes.old == CINEMATIC_STAG_TRAVEL && scenes.current != CINEMATIC_STAG_TRAVEL,
         ),
         // endregion: Bellway
 


### PR DESCRIPTION
> what if the Any Transition and Transition excluding Discontinuities splits didn't split on those transitions to/from the Bellbeast cutscene?
> then when doing IL splits and splitting on rooms, you wouldn't have the dummy split either way: so then, which would you prefer?

> I would like that personally

> I feel like at least Any Transition should still trigger on that
> TED [Transition Excluding Discontinuities] excluding it is justifiable tho