### PR TITLE
Add pre-Sylphsong Eva upgrade splits

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -303,6 +303,9 @@ declare_pointers!(PlayerDataPointers {
     belltown_doctor_cured_curse: UnityPointer<3> = pdp("BelltownDoctorCuredCurse"),
     completed_memory_shaman: UnityPointer<3> = pdp("completedMemory_shaman"),
     has_bound_crest_upgrader: UnityPointer<3> = pdp("HasBoundCrestUpgrader"),
+    current_crest_id: UnityPointer<3> = pdp("CurrentCrestID"),
+    unlocked_extra_blue_slot: UnityPointer<3> = pdp("UnlockedExtraBlueSlot"),
+    unlocked_extra_yellow_slot: UnityPointer<3> = pdp("UnlockedExtraYellowSlot"),
     tool_pouch_upgrades: UnityPointer<3> = pdp("ToolPouchUpgrades"),
     tool_kit_upgrades: UnityPointer<3> = pdp("ToolKitUpgrades"),
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -957,6 +957,22 @@ pub enum Split {
     ///
     /// Splits when leaving the room with the Shaman Crest unlocked
     ShamanCrestTrans,
+    /// Hunter Crest Evolution 1 (Upgrade)
+    ///
+    /// Splits when the first upgrade to the Hunter Crest is obtained
+    HunterCrestEvo1,
+    /// Vesticrest Slot 1 (Upgrade)
+    ///
+    /// Splits when obtaining the Vesticrest yellow tool slot
+    VesticrestYellowSlot,
+    /// Vesticrest Slot 2 (Upgrade)
+    ///
+    /// Splits when obtaining the Vesticrest blue tool slot
+    VesticrestBlueSlot,
+    /// Hunter Crest Evolution 2 (Upgrade)
+    ///
+    /// Splits when the second upgrade to the Hunter Crest is obtained
+    HunterCrestEvo2,
     /// Sylphsong (Skill)
     ///
     /// Splits when obtaining Sylphsong after binding Eva
@@ -2309,6 +2325,21 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
         ),
         Split::ShamanCrest => {
             should_split(mem.deref(&pd.completed_memory_shaman).unwrap_or_default())
+        }
+        Split::HunterCrestEvo1 => {
+            let crest = mem.read_string(&pd.current_crest_id).unwrap_or_default();
+            should_split(crest == "Hunter_v2")
+        }
+        Split::HunterCrestEvo2 => {
+            let crest = mem.read_string(&pd.current_crest_id).unwrap_or_default();
+            should_split(crest == "Hunter_v3")
+        }
+        Split::VesticrestYellowSlot => should_split(
+            mem.deref(&pd.unlocked_extra_yellow_slot)
+                .unwrap_or_default(),
+        ),
+        Split::VesticrestBlueSlot => {
+            should_split(mem.deref(&pd.unlocked_extra_blue_slot).unwrap_or_default())
         }
         Split::Sylphsong => {
             should_split(mem.deref(&pd.has_bound_crest_upgrader).unwrap_or_default())


### PR DESCRIPTION
Being able to access GlobalSettings.Gameplay for the hunter upgrades would be better technically, as it would allow for a simple bool comparison, but ASR seems unable to actually access its members.