### PR TITLE
Add Yarnaby Slap split

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -301,6 +301,7 @@ declare_pointers!(PlayerDataPointers {
     completed_memory_witch: UnityPointer<3> = pdp("completedMemory_witch"),
     gained_curse: UnityPointer<3> = pdp("gainedCurse"),
     belltown_doctor_cured_curse: UnityPointer<3> = pdp("BelltownDoctorCuredCurse"),
+    belltown_doctor_convo: UnityPointer<3> = pdp("BelltownDoctorConvo"),
     completed_memory_shaman: UnityPointer<3> = pdp("completedMemory_shaman"),
     has_bound_crest_upgrader: UnityPointer<3> = pdp("HasBoundCrestUpgrader"),
     tool_pouch_upgrades: UnityPointer<3> = pdp("ToolPouchUpgrades"),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -225,6 +225,10 @@ pub enum Split {
     ///
     /// Splits after entering the basement in Halfway Home
     EnterHalfwayHomeBasement,
+    /// Yarnaby Slap (Event)
+    ///
+    /// Splits when the first dialogue box appears after slapping Yarnaby post Cursed Crest-cure
+    YarnabySlap,
     // endregion: Greymoor
 
     // region: WispThicket
@@ -2021,6 +2025,10 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
                 .unwrap_or_default(),
         ),
         Split::ThreadStorm => should_split(mem.deref(&pd.has_thread_sphere).unwrap_or_default()),
+        Split::YarnabySlap => {
+            let convo_level: i32 = mem.deref(&pd.belltown_doctor_convo).unwrap_or_default();
+            should_split(convo_level == 3)
+        }
         // endregion: Greymoor
 
         // region: WispThicket


### PR DESCRIPTION
This was decided to be the most convenient ending split point for Dapper Slapper / slap%. Unfortunately this is the only one of the three slaps in the route that appears to have a useful player data variable.

Last planned addition of the recent batch.