### PR TITLE
Add pre-commit file for cargo fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+       - id: cargo-fmt
+         name: cargo fmt
+         entry: cargo fmt --
+         language: rust
+         types: [rust]
+         pass_filenames: false


### PR DESCRIPTION
I added this mainly for my own use (so that I can't forget to run `cargo fmt` before pushing updates) with [pre-commit](https://pre-commit.com/). I don't think we need to make this mandatory for the project or anything, but it could be useful to have this file here if anybody else wants use it. If we don't want to add this file to the repository, it should probably be added to the `.gitignore` instead.