### PR TITLE
Start: InitializeGameTime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,9 @@ impl AutoSplitterState {
                         asr::timer::set_variable("delta hits", DASH);
                     }
                 }
+                // InitializeGameTime
+                asr::timer::pause_game_time();
+                asr::timer::resume_game_time();
             }
             TimerState::Paused if self.timer_state == TimerState::Running => {
                 // Pause
@@ -587,6 +590,7 @@ async fn handle_splits(
                 let a = splits::splits(&split, env, trans_now, ss, &mut state.store);
                 match a {
                     SplitterAction::Split => {
+                        // Start
                         asr::timer::start();
                         state.timer_state = TimerState::Running;
                         state.split_index = Some(0);
@@ -605,6 +609,9 @@ async fn handle_splits(
                                 asr::timer::set_variable("delta hits", DASH);
                             }
                         }
+                        // InitializeGameTime
+                        asr::timer::pause_game_time();
+                        asr::timer::resume_game_time();
                         break;
                     }
                     _ => break,


### PR DESCRIPTION
> the timer doesn't display the first row, why is that?

> any reason `Any Transition` would _skip_ a split?

> it definitely happens with start timer at 0 too btw ... interestingly it doesn't happen on the 2nd transition even though I think that has still been less time than the 1st moss grotto room so might be something to do with 1st split specifically

> I'm pretty sure this is only happening with transition splits where the starting split is in the same room

> does anyone know why livesplit is just not tracking my first 2 splits with igt? ... it used to be just the 1st one but now its 1st and 2nd for some reason

> does it only start tracking GameTime after you go through a transition or other load where the GameTime is paused?

> in this case it started splitting on the 2nd load
> which ig its consistent in both cases

> I think the issue might be that LiveSplit doesn't consider the GameTime to be fully initialized until the autosplitter tells it to pause GameTime for the first load

> I think it happens with manual splits too so it's something with the load remover/livesplit