### PR TITLE
Replace Citadel Front Gate split with Enter Grand Gate

### DIFF
--- a/src/splits.rs
+++ b/src/splits.rs
@@ -324,10 +324,6 @@ pub enum Split {
     ///
     /// Splits when killing Last Judge
     LastJudge,
-    /// Enter Citadel Front Gate (Transition)
-    ///
-    /// Splits when entering the Citadel past the Last Judge arena
-    EnterCitadelFrontGate,
     // endregion: BlastedSteps
 
     // region: SinnersRoad
@@ -522,6 +518,14 @@ pub enum Split {
     #[alias = "WhisperingVaultsGauntlet"]
     WhisperingVaultsArena,
     // endregion: WhisperingVaults
+
+    // region: GrandGate
+    /// Enter Grand Gate (Transition)
+    ///
+    /// Splits when entering the Grand Gate region, past the Last Judge door or into the top of the scales room
+    #[alias = "EnterCitadelFrontGate"]
+    EnterGrandGate,
+    // endregion: GrandGate
 
     // region: ChoralChambers
     /// Enter Songclave (Transition)
@@ -1915,9 +1919,6 @@ pub fn transition_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> Splitte
         Split::EnterLastJudge => {
             should_split(scenes.old == "Coral_32" && scenes.current == "Coral_Judge_Arena")
         }
-        Split::EnterCitadelFrontGate => {
-            should_split(scenes.old == "Coral_Judge_Arena" && scenes.current == "Coral_10")
-        }
         // endregion: BlastedSteps
 
         // region: SinnersRoad
@@ -1997,6 +1998,13 @@ pub fn transition_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> Splitte
                 .unwrap_or_default(),
         ),
         // endregion: SandsOfKarak
+
+        // region: GrandGate
+        Split::EnterGrandGate => should_split(
+            (scenes.old == "Coral_Judge_Arena" && scenes.current == "Coral_10")
+                || (scenes.old == "Song_01c" && scenes.current == "Song_19_entrance"),
+        ),
+        // endregion: GrandGate
 
         // region: ChoralChambers
         Split::EnterSongclave => should_split(


### PR DESCRIPTION
Covers both entrances into the area that could trigger area text that I found - none of the lower transitions seem to. Song_01c to _19_entrance only triggers if the previous scene was _01, but for any realstic use case for this that'll be true.