### PR TITLE
Add Enter Choral Chambers split

### DIFF
--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2003,30 +2003,27 @@ pub fn transition_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> Splitte
         // endregion: SandsOfKarak
 
         // region: ChoralChambers
-        Split::EnterChoralChambers => {
-            // first, run the check that may require another read from memory
-            if scenes.old == "Library_02" && scenes.current == "Song_20b" {
-                let gate = mem.read_string(&gm.entry_gate_name).unwrap_or_default();
-                should_split(gate == "right2")
-            } else {
-                should_split(
-                    (scenes.old == "Slab_01" && scenes.current == "Song_04")
-                        || (scenes.old == "Song_01c" && scenes.current == "Song_01")
-                        || (scenes.old == "Bellway_City" && scenes.current == "Song_20")
-                        || (scenes.old == "Library_13" && scenes.current == "Song_20")
-                        || (scenes.old == "Library_03" && scenes.current == "Song_20")
-                        || (scenes.old == "Arborium_01" && scenes.current == "Song_25")
-                        || (scenes.old == "Song_Enclave" && scenes.current == "Song_25")
-                        || (scenes.old == "Ward_01" && scenes.current == "Song_05")
-                        || (scenes.old == "Cog_Dancers"
-                            && (scenes.current == "Hang_07" || scenes.current == "Song_25"))
-                        || (scenes.old == "Hang_01" && scenes.current == "Song_17")
-                        || (scenes.old == "Hang_06" && scenes.current == "Hang_07")
-                        || (scenes.old == "Cog_10_Destroyed" && scenes.current == "Song_25")
-                        || (scenes.old == "Under_07b" && scenes.current == "Song_01"),
-                )
-            }
-        }
+        Split::EnterChoralChambers => should_split(
+            (scenes.old == "Slab_01" && scenes.current == "Song_04")
+                || (scenes.old == "Song_01c" && scenes.current == "Song_01")
+                || (scenes.old == "Bellway_City" && scenes.current == "Song_20")
+                || (scenes.old == "Library_13" && scenes.current == "Song_20")
+                || (scenes.old == "Library_03" && scenes.current == "Song_20")
+                || (scenes.old == "Arborium_01" && scenes.current == "Song_25")
+                || (scenes.old == "Song_Enclave" && scenes.current == "Song_25")
+                || (scenes.old == "Ward_01" && scenes.current == "Song_05")
+                || (scenes.old == "Cog_Dancers"
+                    && (scenes.current == "Hang_07" || scenes.current == "Song_25"))
+                || (scenes.old == "Hang_01" && scenes.current == "Song_17")
+                || (scenes.old == "Hang_06" && scenes.current == "Hang_07")
+                || (scenes.old == "Cog_10_Destroyed" && scenes.current == "Song_25")
+                || (scenes.old == "Under_07b" && scenes.current == "Song_01")
+                || (scenes.old == "Library_02"
+                    && scenes.current == "Song_20b"
+                    && mem
+                        .read_string(&gm.entry_gate_name)
+                        .is_some_and(|gate| gate == "right2")),
+        ),
         Split::EnterSongclave => should_split(
             (scenes.old == "Song_Enclave_Tube"
                 || scenes.old == "Song_25"


### PR DESCRIPTION
Been putting this one off for a while because of the sheer number of
transitions, but I think this is all of them. Note that a few of these
only make the area text appear if coming from deeper into a 'region'
(e.g. CWD to left/right transitions only causes area text to appear if
coming from upper/lower cogwork core), but we don't track that
information and users generally don't add a split like this unless it's
on a place where it actually gives some useful information.