### PR TITLE
Don't pause on transition w/ isInventoryOpen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,6 +529,7 @@ async fn main() {
                 let _: Address64 = mem.deref(&gm.next_scene_name).unwrap_or_default();
                 let _: Address64 = mem.deref(&gm.scene_name).unwrap_or_default();
                 let _: i32 = mem.deref(&gm.ui_state_vanilla).unwrap_or_default();
+                let _: bool = mem.deref(&pd.is_inventory_open).unwrap_or_default();
                 let _: i32 = mem.deref(&pd.health).unwrap_or_default();
                 state
                     .store
@@ -749,7 +750,7 @@ fn load_removal(state: &mut AutoSplitterState, e: &Env) {
         return;
     }
 
-    let Env { mem, gm, .. } = e;
+    let Env { mem, gm, pd } = e;
 
     let ui_state: i32 = mem.deref(&gm.ui_state_vanilla).unwrap_or_default();
     let scene_name = mem.read_string(&gm.scene_name).unwrap_or_default();
@@ -797,6 +798,7 @@ fn load_removal(state: &mut AutoSplitterState, e: &Env) {
     let scene_load_activation_allowed: bool = mem
         .deref(&gm.scene_load_activation_allowed)
         .unwrap_or_default();
+    let is_inventory_open: bool = mem.deref(&pd.is_inventory_open).unwrap_or_default();
     // TODO: tile_map_dirty, uses_scene_transition_routine
 
     let is_game_time_paused = (state.look_for_teleporting)
@@ -808,9 +810,11 @@ fn load_removal(state: &mut AutoSplitterState, e: &Env) {
             && !state.mms_room_dupe)
         || ((game_state == GAME_STATE_EXITING_LEVEL
             && (scene_load_null || scene_load_activation_allowed)
+            && !is_inventory_open
             && !state.mms_room_dupe)
             || game_state == GAME_STATE_LOADING)
-        || (hero_transition_state == HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL)
+        || (hero_transition_state == HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL
+            && !is_inventory_open)
         || (ui_state != UI_STATE_PLAYING
             && (loading_menu
                 || (ui_state != UI_STATE_PAUSED

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -246,6 +246,7 @@ fn pdp(key: &'static str) -> UnityPointer<3> {
 
 declare_pointers!(PlayerDataPointers {
     disable_pause: UnityPointer<3> = pdp("disablePause"),
+    is_inventory_open: UnityPointer<3> = pdp("isInventoryOpen"),
     health: UnityPointer<3> = pdp("health"),
     max_health_base: UnityPointer<3> = pdp("maxHealthBase"),
     heart_pieces: UnityPointer<3> = pdp("heartPieces"),


### PR DESCRIPTION
> (requires bench storage) it's currently possible to open inventory during a load which keeps the timer paused, is there a way this could be fixed?
