### PR TITLE
Add other requested boss splits

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -479,6 +479,8 @@ declare_pointers!(PlayerDataPointers {
     defeated_zap_core_enemy: UnityPointer<3> = pdp("defeatedZapCoreEnemy"),
     defeated_coral_driller_solo: UnityPointer<3> = pdp("defeatedCoralDrillerSolo"),
     defeated_grey_warrior: UnityPointer<3> = pdp("defeatedGreyWarrior"),
+    defeated_lost_garmond: UnityPointer<3> = pdp("garmondBlackThreadDefeated"),
+    encountered_plasmified_zango: UnityPointer<3> = pdp("BlueAssistantEnemyEncountered"),
     encountered_lost_lace: UnityPointer<3> = pdp("EncounteredLostLace"),
     completion_percentage: UnityPointer<3> = pdp("completionPercentage"),
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -157,6 +157,10 @@ pub enum Split {
     ///
     /// Splits on the transition after obtaining Sharpdart
     SharpdartTrans,
+    /// Plasmified Zango Encountered (Boss)
+    ///
+    /// Splits when encountering the Plasmified Zango boss for the first time
+    PlasmifiedZangoEncountered,
     // endregion: Wormways
 
     // region: HuntersMarch
@@ -340,6 +344,10 @@ pub enum Split {
     ///
     /// Splits when killing Last Judge
     LastJudge,
+    /// Lost Garmond (Boss)
+    ///
+    /// Splits when defeating Lost Garmond
+    LostGarmond,
     // endregion: BlastedSteps
 
     // region: SinnersRoad
@@ -691,6 +699,10 @@ pub enum Split {
     // endregion: PutrifiedDucts
 
     // region: TheCradle
+    /// Enter Lace 2 (Transition)
+    ///
+    /// Splits when entering the Lace 2 boss arena
+    EnterLace2,
     /// Lace 2 (Boss)
     ///
     /// Splits when defeating Lace 2 in the Cradle
@@ -2161,6 +2173,9 @@ pub fn transition_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> Splitte
         // endregion: PutrifiedDucts
 
         // region: TheCradle
+        Split::EnterLace2 => {
+            should_split(scenes.old == "Cog_Dancers" && scenes.current == "Song_Tower_01")
+        }
         Split::PostLace2ArenaTrans => {
             should_split(scenes.old == "Song_Tower_01" && scenes.current == "Tube_Hub")
         }
@@ -2363,6 +2378,10 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
 
         // region: Wormways
         Split::Sharpdart => should_split(mem.deref(&pd.has_silk_charge).unwrap_or_default()),
+        Split::PlasmifiedZangoEncountered => should_split(
+            mem.deref(&pd.encountered_plasmified_zango)
+                .unwrap_or_default(),
+        ),
         // endregion: Wormways
 
         // region: FarFields
@@ -2435,6 +2454,9 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
             should_split(mem.deref(&pd.encountered_last_judge).unwrap_or_default())
         }
         Split::LastJudge => should_split(mem.deref(&pd.defeated_last_judge).unwrap_or_default()),
+        Split::LostGarmond => {
+            should_split(mem.deref(&pd.defeated_lost_garmond).unwrap_or_default())
+        }
         // endregion: BlastedSteps
 
         // region: SinnersRoad


### PR DESCRIPTION
Lost Garmond does split when killed, not afterwards related to any quest completion, etc.
Zango boss kill data seems to be in SceneData entirely, so the playerdata encounter variable is useful as a reminder for people running All Bosses.