### PR TITLE
Add Trail's End (Menu) split

### DIFF
--- a/src/splits.rs
+++ b/src/splits.rs
@@ -410,6 +410,10 @@ pub enum Split {
     ///
     /// Splits on the transition out of the room to complete Trail's End
     TrailsEndTrans,
+    /// Trail's End (Menu)
+    ///
+    /// Splits on the main menu when quitting out of the Trails's End room
+    TrailsEndMenu,
     // endregion: Bilewater
 
     // region: TheSlab
@@ -1851,6 +1855,10 @@ pub fn menu_splits(
                 && store.get_string("respawn_scene").unwrap_or_default() == "Belltown_Shrine",
         ),
         // endregion: Bellhart
+
+        // region: Bilewater
+        Split::TrailsEndMenu => should_split(scenes.changed_from(&"Shadow_24")),
+        // endregion: Bilewater
 
         // else
         _ => should_split(false),


### PR DESCRIPTION
Currently implemented via an ad-hoc menu split in TE comsob, but not a direct request, per se.

As far as I can tell, the current-scene-menu check is unnecessary given the previous checks to dispatch to `fn menu_splits`, including contrived scenarios like quitting out twice in a row.