### PR TITLE
Add Skarrgard 2 and 3 splits

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -466,6 +466,8 @@ declare_pointers!(PlayerDataPointers {
     defeated_first_weaver: UnityPointer<3> = pdp("defeatedFirstWeaver"),
     encountered_ant_trapper: UnityPointer<3> = pdp("encounteredAntTrapper"),
     defeated_ant_trapper: UnityPointer<3> = pdp("defeatedAntTrapper"),
+    skarrgard_2_defeated: UnityPointer<3> = pdp("ant21_InitBattleCompleted"),
+    skarrgard_3_defeated: UnityPointer<3> = pdp("defeatedGuardBoneEast25"),
 
     savedflea_ant_03: UnityPointer<3> = pdp("SavedFlea_Ant_03"),
     savedflea_belltown_04: UnityPointer<3> = pdp("SavedFlea_Belltown_04"),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -171,12 +171,16 @@ pub enum Split {
     /// Enter Hunter's March (Transition)
     ///
     /// Splits on entering a Hunter's March transition with area text
-    /// (includes post-Skarrguard room and tall room)
+    /// (includes post-Skarrgard room and tall room)
     EnterHuntersMarch,
     /// Hunter's March - Post-Middle Arena (Transition)
     ///
     /// Splits on transition to the room after the middle arena in Hunter's March
     HuntersMarchPostMiddleArenaTransition,
+    /// Skarrgard 2 (Mini Boss)
+    ///
+    /// Splits when defeating the Skarrgard encounter guarding rosary strings in Hunter's March (Ant_21)
+    Skarrgard2,
     // endregion: HuntersMarch
 
     // region: FarFields
@@ -204,6 +208,10 @@ pub enum Split {
     ///
     /// Splits when Gurr the Outcast is defeated
     GurrTheOutcast,
+    /// Skarrgard 3 (Mini Boss)
+    ///
+    /// Splits when defeating the Skarrguard beside Karmelita (Bone_East_25)
+    Skarrgard3,
     /// Enter Sprintmaster Cave (Transition)
     ///
     /// Splits when entering the room containing Sprintmaster Swift
@@ -2484,6 +2492,10 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
         ),
         // endregion: Wormways
 
+        // region: HuntersMarch
+        Split::Skarrgard2 => should_split(mem.deref(&pd.skarrgard_2_defeated).unwrap_or_default()),
+        // endregion: HuntersMarch
+
         // region: FarFields
         Split::DriftersCloak => should_split(mem.deref(&pd.has_brolly).unwrap_or_default()),
         Split::FourthChorus => should_split(mem.deref(&pd.defeated_song_golem).unwrap_or_default()),
@@ -2493,6 +2505,7 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
         Split::GurrTheOutcast => {
             should_split(mem.deref(&pd.defeated_ant_trapper).unwrap_or_default())
         }
+        Split::Skarrgard3 => should_split(mem.deref(&pd.skarrgard_3_defeated).unwrap_or_default()),
         // endregion: FarFields
 
         // region: Greymoor


### PR DESCRIPTION
Note that, although "ant02GuardDefeated" seems like it should correspond to the Skarrgard in Ant_02, as far as I am aware that variable is never triggered, at least by anything that resembles defeating the Skarrgard.

