### PR TITLE
Unify four-level upgrade splits: split when equal, skip when greater than expected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,7 +754,7 @@ async fn handle_splits(
                 };
                 let a = splits::splits(&split, env, trans_now, ss, &mut state.store);
                 match a {
-                    SplitterAction::Split => {
+                    Some(SplitterAction::Split) => {
                         // Start
                         asr::timer::start();
                         state.timer_state = TimerState::Running;
@@ -805,7 +805,7 @@ async fn handle_splits(
                 };
                 let a = splits::splits(&split, env, trans_now, ss, &mut state.store);
                 match a {
-                    SplitterAction::Reset => {
+                    Some(SplitterAction::Reset) => {
                         if settings.get_hit_counter() {
                             Settings::update_comparison_hits(
                                 &mut state.comparison_hits,
@@ -855,7 +855,7 @@ async fn handle_splits(
                         }
                         // no break, allow other actions after a skip or reset
                     }
-                    SplitterAction::Skip => {
+                    Some(SplitterAction::Skip) => {
                         let old_index = state.split_index.unwrap_or_default();
                         let old_i = old_index as usize;
                         asr::timer::skip_split();
@@ -895,7 +895,7 @@ async fn handle_splits(
                         }
                         // no break, allow other actions after a skip or reset
                     }
-                    SplitterAction::Split => {
+                    Some(SplitterAction::Split) => {
                         let old_index = state.split_index.unwrap_or_default();
                         asr::timer::split();
                         let new_i = old_index as usize + 1;
@@ -936,7 +936,7 @@ async fn handle_splits(
                         }
                         break;
                     }
-                    SplitterAction::ManualSplit => {
+                    Some(SplitterAction::ManualSplit) => {
                         #[cfg(not(feature = "split-index"))]
                         if let Some(old_index) = state.split_index {
                             let old_i = old_index as usize;

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1884,7 +1884,7 @@ pub fn menu_splits(
     scenes: &Pair<&str>,
     _e: &Env,
     store: &mut Store,
-) -> SplitterAction {
+) -> Option<SplitterAction> {
     match split {
         // region: Start, End, and Menu
         Split::Menu => should_split(scenes.current == MENU_TITLE),
@@ -1924,7 +1924,7 @@ pub fn transition_splits(
     scenes: &Pair<&str>,
     e: &Env,
     split_this_transition: bool,
-) -> SplitterAction {
+) -> Option<SplitterAction> {
     let Env { mem, pd, gm } = e;
     match split {
         // region: Start, End, and Menu
@@ -2380,7 +2380,11 @@ pub fn transition_splits(
     }
 }
 
-pub fn transition_once_splits(split: &Split, scenes: &Pair<&str>, e: &Env) -> SplitterAction {
+pub fn transition_once_splits(
+    split: &Split,
+    scenes: &Pair<&str>,
+    e: &Env,
+) -> Option<SplitterAction> {
     let Env { mem, gm, pd } = e;
     match split {
         // region: Start, End, and Menu
@@ -2433,7 +2437,7 @@ fn bench_split(store: &mut Store, e: &Env) -> bool {
         .is_some_and(|p| p.changed_to(&true))
 }
 
-pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterAction {
+pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<SplitterAction> {
     let Env { mem, gm, pd } = e;
     let game_state: i32 = mem.deref(&gm.game_state).unwrap_or_default();
     if !NON_MENU_GAME_STATES.contains(&game_state) {
@@ -2441,7 +2445,7 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> SplitterA
     }
     match split {
         // region: Start, End, and Menu
-        Split::ManualSplit => SplitterAction::ManualSplit,
+        Split::ManualSplit => Some(SplitterAction::ManualSplit),
         Split::BenchAny => should_split(bench_split(store, e)),
         Split::PlayerDeath => should_split(
             store
@@ -3344,13 +3348,13 @@ pub fn splits(
     trans_now: bool,
     ss: &mut SceneStore,
     store: &mut Store,
-) -> SplitterAction {
+) -> Option<SplitterAction> {
     let a1 = continuous_splits(split, env, store).or_else(|| {
         let scenes = ss.pair();
         let a2 = if !ss.split_this_transition {
             transition_once_splits(split, &scenes, env)
         } else {
-            SplitterAction::Pass
+            None
         };
         a2.or_else(|| {
             if trans_now {
@@ -3360,11 +3364,11 @@ pub fn splits(
                     transition_splits(split, &scenes, env, ss.split_this_transition)
                 }
             } else {
-                SplitterAction::Pass
+                None
             }
         })
     });
-    if a1 != SplitterAction::Pass {
+    if a1.is_some() {
         ss.split_this_transition = true;
     }
     a1

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -14,7 +14,7 @@ use crate::{
         MENU_TITLE, NON_MENU_GAME_STATES, OPENING_SCENES,
     },
     store::Store,
-    timer::{should_split, SplitterAction},
+    timer::{reached_up_to_split, should_split, SplitterAction},
 };
 
 #[derive(Clone, Debug, Default, Eq, Gui, Ord, PartialEq, PartialOrd, RadioButtonOptions)]
@@ -2741,18 +2741,10 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<Sp
         // endregion: ThreefoldMelody
 
         // region: NeedleUpgrade
-        Split::NeedleUpgrade1 => {
-            should_split(mem.deref(&pd.nail_upgrades).is_ok_and(|n: i32| n >= 1))
-        }
-        Split::NeedleUpgrade2 => {
-            should_split(mem.deref(&pd.nail_upgrades).is_ok_and(|n: i32| n >= 2))
-        }
-        Split::NeedleUpgrade3 => {
-            should_split(mem.deref(&pd.nail_upgrades).is_ok_and(|n: i32| n >= 3))
-        }
-        Split::NeedleUpgrade4 => {
-            should_split(mem.deref(&pd.nail_upgrades).is_ok_and(|n: i32| n >= 4))
-        }
+        Split::NeedleUpgrade1 => reached_up_to_split(1, mem.deref(&pd.nail_upgrades)),
+        Split::NeedleUpgrade2 => reached_up_to_split(2, mem.deref(&pd.nail_upgrades)),
+        Split::NeedleUpgrade3 => reached_up_to_split(3, mem.deref(&pd.nail_upgrades)),
+        Split::NeedleUpgrade4 => reached_up_to_split(4, mem.deref(&pd.nail_upgrades)),
         // endregion: NeedleUpgrade
 
         // region: MaskShards
@@ -2820,37 +2812,17 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<Sp
         // endregion SpoolFragments
 
         // region: ToolPouchLevels
-        Split::ToolPouch1 => should_split(
-            mem.deref(&pd.tool_pouch_upgrades)
-                .is_ok_and(|n: i32| n == 1),
-        ),
-        Split::ToolPouch2 => should_split(
-            mem.deref(&pd.tool_pouch_upgrades)
-                .is_ok_and(|n: i32| n == 2),
-        ),
-        Split::ToolPouch3 => should_split(
-            mem.deref(&pd.tool_pouch_upgrades)
-                .is_ok_and(|n: i32| n == 3),
-        ),
-        Split::ToolPouch4 => should_split(
-            mem.deref(&pd.tool_pouch_upgrades)
-                .is_ok_and(|n: i32| n == 4),
-        ),
+        Split::ToolPouch1 => reached_up_to_split(1, mem.deref(&pd.tool_pouch_upgrades)),
+        Split::ToolPouch2 => reached_up_to_split(2, mem.deref(&pd.tool_pouch_upgrades)),
+        Split::ToolPouch3 => reached_up_to_split(3, mem.deref(&pd.tool_pouch_upgrades)),
+        Split::ToolPouch4 => reached_up_to_split(4, mem.deref(&pd.tool_pouch_upgrades)),
         // endregion: ToolPouchLevels
 
         // region: CraftingKitLevels
-        Split::CraftingKit1 => {
-            should_split(mem.deref(&pd.tool_kit_upgrades).is_ok_and(|n: i32| n == 1))
-        }
-        Split::CraftingKit2 => {
-            should_split(mem.deref(&pd.tool_kit_upgrades).is_ok_and(|n: i32| n == 2))
-        }
-        Split::CraftingKit3 => {
-            should_split(mem.deref(&pd.tool_kit_upgrades).is_ok_and(|n: i32| n == 3))
-        }
-        Split::CraftingKit4 => {
-            should_split(mem.deref(&pd.tool_kit_upgrades).is_ok_and(|n: i32| n == 4))
-        }
+        Split::CraftingKit1 => reached_up_to_split(1, mem.deref(&pd.tool_kit_upgrades)),
+        Split::CraftingKit2 => reached_up_to_split(2, mem.deref(&pd.tool_kit_upgrades)),
+        Split::CraftingKit3 => reached_up_to_split(3, mem.deref(&pd.tool_kit_upgrades)),
+        Split::CraftingKit4 => reached_up_to_split(4, mem.deref(&pd.tool_kit_upgrades)),
         // endregion: CraftingKitLevels
 
         // region: Crests

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,27 +1,16 @@
-#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[allow(dead_code)]
 pub enum SplitterAction {
-    #[default]
-    Pass,
     Split,
     Skip,
     Reset,
     ManualSplit,
 }
 
-impl SplitterAction {
-    pub fn or_else<F: FnOnce() -> SplitterAction>(self, f: F) -> SplitterAction {
-        match self {
-            SplitterAction::Pass => f(),
-            a => a,
-        }
-    }
-}
-
-pub fn should_split(b: bool) -> SplitterAction {
+pub fn should_split(b: bool) -> Option<SplitterAction> {
     if b {
-        SplitterAction::Split
+        Some(SplitterAction::Split)
     } else {
-        SplitterAction::Pass
+        None
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,3 +1,5 @@
+use core::cmp::Ordering;
+
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[allow(dead_code)]
 pub enum SplitterAction {
@@ -12,5 +14,14 @@ pub fn should_split(b: bool) -> Option<SplitterAction> {
         Some(SplitterAction::Split)
     } else {
         None
+    }
+}
+
+/// Splits when equal, skips when greater than expected
+pub fn reached_up_to_split<T: PartialOrd>(expected: T, actual: Result<T, asr::Error>) -> Option<SplitterAction> {
+    match actual.ok()?.partial_cmp(&expected)? {
+        Ordering::Equal => Some(SplitterAction::Split),
+        Ordering::Greater => Some(SplitterAction::Skip),
+        _ => None
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -18,10 +18,13 @@ pub fn should_split(b: bool) -> Option<SplitterAction> {
 }
 
 /// Splits when equal, skips when greater than expected
-pub fn reached_up_to_split<T: PartialOrd>(expected: T, actual: Result<T, asr::Error>) -> Option<SplitterAction> {
+pub fn reached_up_to_split<T: PartialOrd>(
+    expected: T,
+    actual: Result<T, asr::Error>,
+) -> Option<SplitterAction> {
     match actual.ok()?.partial_cmp(&expected)? {
         Ordering::Equal => Some(SplitterAction::Split),
         Ordering::Greater => Some(SplitterAction::Skip),
-        _ => None
+        _ => None,
     }
 }


### PR DESCRIPTION
Fixes #167 by making them all behave the same way: splitting when equal to the expected level, and skipping when greater than the expected level.

The key function is this:
```rust
/// Splits when equal, skips when greater than expected
pub fn reached_up_to_split<T: PartialOrd>(
    expected: T,
    actual: Result<T, asr::Error>,
) -> Option<SplitterAction> {
    match actual.ok()?.partial_cmp(&expected)? {
        Ordering::Equal => Some(SplitterAction::Split),
        Ordering::Greater => Some(SplitterAction::Skip),
        _ => None,
    }
}
```

Testing:
- [x] Needle
  - [x] No action when less
  - [x] Splits when equal
  - [x] Skips when greater
- [x] Crafting Kit
  - [x] No action when less
  - [x] Splits when equal
  - [x] Skips when greater
- [x] Tool Pouch
  - [x] No action when less
  - [x] Splits when equal
  - [x] Skips when greater