### PR TITLE
Add adbg! macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,31 @@ asr::async_main!(stable);
 #[cfg(target_os = "unknown")]
 asr::panic_handler!();
 
+// This is copy-pasted from the standard library macro `dbg!`, but modified to output to asr.
+#[allow(unused)]
+macro_rules! adbg {
+    () => {
+        asr::print_message(&alloc::format!("[{}:{}:{}]", file!(), line!(), column!()))
+    };
+    ($val:expr $(,)?) => {
+        match $val {
+            tmp => {
+                asr::print_message(&alloc::format!("[{}:{}:{}] {} = {:#?}",
+                    file!(),
+                    line!(),
+                    column!(),
+                    stringify!($val),
+                    &&tmp as &dyn alloc::fmt::Debug,
+                ));
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($(adbg!($val)),+,)
+    };
+}
+
 // --------------------------------------------------------
 
 static MODULE_PATH: &str = module_path!();


### PR DESCRIPTION
I've reimplemented this twice now when trying to debug autosplitter code and I figure it's probably best to just get this into the codebase for future debugging. This is exactly the same as the standard library `dbg!` macro, except instead of using `eprintln!` for formatting, it calls `format!` before outputting to `asr::print_message`. This shouldn't ever be used in any code that makes it in to a main release, but I often test builds like this with release mode so I didn't want to make it configured to be debug-build-only.