### PR TITLE
Don't pause on UI_STATE_CUTSCENE

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1082,9 +1082,11 @@ fn load_removal(settings: &Settings, state: &mut AutoSplitterState, e: &Env) {
             && ui_state != UI_STATE_PLAYING)
         || (game_state != GAME_STATE_PLAYING
             && game_state != GAME_STATE_CUTSCENE
+            && ui_state != UI_STATE_CUTSCENE
             && !accepting_input
             && !state.mms_room_dupe)
         || ((game_state == GAME_STATE_EXITING_LEVEL
+            && ui_state != UI_STATE_CUTSCENE
             && (scene_load_null || scene_load_activation_allowed)
             && !is_inventory_open
             && !state.mms_room_dupe)


### PR DESCRIPTION
An attempt to fix #126. In my testing, 3 out of 4 times it worked fine, with game_state going from 6 (Entering Level) to 7 (Cutscene) for the Opening_Sequence_Act3 cutscene, but on the 4th time, game_state stayed at 6 (Entering Level) for the entire Opening_Sequence_Act3 cutscene, which was causing the timer to pause, thinking it was still in a load. The only variable I could see that changed was the ui_state, which went to 3 (Cutscene) during the cutscene. So, this change makes it check that ui_state is not 3 (Cutscene).