### PR TITLE
Glitched duped-self transitions for AnyTransition and TransitionExcludingDiscontinuities

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -728,6 +728,7 @@ pub struct SceneStore {
     new_data_curr: bool,
     new_data_next: bool,
     last_next: bool,
+    last_scene_load_activation_allowed: bool,
     pub split_this_transition: bool,
 }
 
@@ -740,6 +741,7 @@ impl SceneStore {
             new_data_curr: false,
             new_data_next: false,
             last_next: true,
+            last_scene_load_activation_allowed: false,
             split_this_transition: false,
         }
     }
@@ -794,6 +796,9 @@ impl SceneStore {
         if scene_load_null || scene_load_activation_allowed {
             self.new_next_scene_name(mem.read_string(&gm.next_scene_name).unwrap_or_default());
         }
+        let new_scene_load_activation_allowed =
+            !self.last_scene_load_activation_allowed && scene_load_activation_allowed;
+        self.last_scene_load_activation_allowed = scene_load_activation_allowed;
 
         if self.new_data_next {
             self.new_data_curr = false;
@@ -831,7 +836,7 @@ impl SceneStore {
             ));
             true
         } else {
-            false
+            new_scene_load_activation_allowed
         }
     }
 }

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -835,8 +835,11 @@ impl SceneStore {
                 &self.prev_scene_name, &self.curr_scene_name
             ));
             true
+        } else if new_scene_load_activation_allowed {
+            self.split_this_transition = false;
+            true
         } else {
-            new_scene_load_activation_allowed
+            false
         }
     }
 }


### PR DESCRIPTION
> https://www.twitch.tv/zoezkb/clip/KawaiiRenownedWaffleKippa-Y5IXWkJSMmu0uslP
> autosplitter any-transition problem

> its failing on splitting with the list of loaded rooms(oldest to newest) going [tut_02,tut_01] -> [tut_01,tut_01] in debug

> have a glitches any-trans autosplitter thing not splitting(I have also just confirmed it with a room timer)

> I watched my grotto IL back and actually yes i was missing the exact split that happens to be broken