### PR TITLE
Fix Crest Transition autosplits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
           rust-version: '1.95.0'
           targets: wasm32-unknown-unknown
 
+      - name: Install Target
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Build
         run: |
           cargo b --release --locked ${{matrix.features}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: stable
+          rust-version: '1.95.0'
           targets: wasm32-unknown-unknown
 
       - name: Install Target

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             sleep: 10
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2
@@ -52,7 +52,7 @@ jobs:
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: silksong_autosplit_wasm*.wasm
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: '1.95.0'
+          rust-version: stable
           targets: wasm32-unknown-unknown
 
       - name: Install Target

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: stable
+          rust-version: '1.95.0'
           targets: wasm32-unknown-unknown
 
       - name: Build

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1956,10 +1956,12 @@ pub fn transition_splits(
         // endregion: Start, End, and Menu
 
         // region: MossLands
-        Split::MossMotherTrans => {
-            should_split(mem.deref(&pd.defeated_moss_mother).unwrap_or_default())
+        Split::MossMotherTrans => should_split(
+            scenes.changed() && mem.deref(&pd.defeated_moss_mother).unwrap_or_default(),
+        ),
+        Split::SilkSpearTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_needle_throw).unwrap_or_default())
         }
-        Split::SilkSpearTrans => should_split(mem.deref(&pd.has_needle_throw).unwrap_or_default()),
         Split::EnterBoneBottom => should_split(scenes.changed_to(&"Bonetown")),
         Split::EnterMosshome => {
             should_split(scenes.old == "Bone_05" && scenes.current == "Mosstown_01")
@@ -1971,13 +1973,17 @@ pub fn transition_splits(
 
         // region: Marrow
         Split::BellBeastTrans => {
-            should_split(mem.deref(&pd.defeated_bell_beast).unwrap_or_default())
+            should_split(scenes.changed() && mem.deref(&pd.defeated_bell_beast).unwrap_or_default())
         }
         // endregion: Marrow
 
         // region: DeepDocks
-        Split::SwiftStepTrans => should_split(mem.deref(&pd.has_dash).unwrap_or_default()),
-        Split::Lace1Trans => should_split(mem.deref(&pd.defeated_lace1).unwrap_or_default()),
+        Split::SwiftStepTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_dash).unwrap_or_default())
+        }
+        Split::Lace1Trans => {
+            should_split(scenes.changed() && mem.deref(&pd.defeated_lace1).unwrap_or_default())
+        }
         // endregion: DeepDocks
 
         // region: Wormways
@@ -1988,7 +1994,9 @@ pub fn transition_splits(
         Split::EnterUpperWormways => {
             should_split(scenes.old == "Crawl_03b" && scenes.current == "Crawl_03")
         }
-        Split::SharpdartTrans => should_split(mem.deref(&pd.has_silk_charge).unwrap_or_default()),
+        Split::SharpdartTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_silk_charge).unwrap_or_default())
+        }
         // endregion: Wormways
 
         // region: HuntersMarch
@@ -2005,7 +2013,9 @@ pub fn transition_splits(
         Split::EnterFarFields => should_split(
             !scenes.old.starts_with("Bone_East") && scenes.current.starts_with("Bone_East"),
         ),
-        Split::DriftersCloakTrans => should_split(mem.deref(&pd.has_brolly).unwrap_or_default()),
+        Split::DriftersCloakTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_brolly).unwrap_or_default())
+        }
         Split::EnterSprintmasterCave => should_split(scenes.changed_to(&"Sprintmaster_Cave")),
         // endregion: FarFields
 
@@ -2014,11 +2024,13 @@ pub fn transition_splits(
             !scenes.old.starts_with("Greymoor") && scenes.current.starts_with("Greymoor"),
         ),
         Split::MoorwingTrans => should_split(
-            mem.deref(&pd.defeated_vampire_gnat_boss)
-                .unwrap_or_default(),
+            scenes.changed()
+                && mem
+                    .deref(&pd.defeated_vampire_gnat_boss)
+                    .unwrap_or_default(),
         ),
         Split::ThreadStormTrans => {
-            should_split(mem.deref(&pd.has_thread_sphere).unwrap_or_default())
+            should_split(scenes.changed() && mem.deref(&pd.has_thread_sphere).unwrap_or_default())
         }
         Split::EnterHalfwayHomeBasement => {
             should_split(scenes.old == "Halfway_01" && scenes.current == "Ant_08")
@@ -2047,10 +2059,12 @@ pub fn transition_splits(
         // endregion: Bellhart
 
         // region: Shellwood
-        Split::ClingGripTrans => should_split(mem.deref(&pd.has_wall_jump).unwrap_or_default()),
-        Split::SisterSplinterTrans => {
-            should_split(mem.deref(&pd.defeated_sister_splinter).unwrap_or_default())
+        Split::ClingGripTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_wall_jump).unwrap_or_default())
         }
+        Split::SisterSplinterTrans => should_split(
+            scenes.changed() && mem.deref(&pd.defeated_sister_splinter).unwrap_or_default(),
+        ),
         Split::EnterShellwood => should_split(
             !scenes.old.starts_with("Shellwood") && scenes.current.starts_with("Shellwood"),
         ),
@@ -2060,11 +2074,11 @@ pub fn transition_splits(
         Split::EnterBlastedSteps => {
             should_split(scenes.old == "Coral_19" && scenes.current == "Coral_02")
         }
-        Split::GreatConchfliesTrans => {
-            should_split(mem.deref(&pd.defeated_coral_drillers).unwrap_or_default())
-        }
+        Split::GreatConchfliesTrans => should_split(
+            scenes.changed() && mem.deref(&pd.defeated_coral_drillers).unwrap_or_default(),
+        ),
         Split::NeedleStrikeTrans => {
-            should_split(mem.deref(&pd.has_charge_slash).unwrap_or_default())
+            should_split(scenes.changed() && mem.deref(&pd.has_charge_slash).unwrap_or_default())
         }
         Split::EnterLastJudge => {
             should_split(scenes.old == "Coral_32" && scenes.current == "Coral_Judge_Arena")
@@ -2103,8 +2117,12 @@ pub fn transition_splits(
         Split::EnterExhaustOrgan => {
             should_split(scenes.old == "Dust_09" && scenes.current == "Organ_01")
         }
-        Split::PhantomTrans => should_split(mem.deref(&pd.defeated_phantom).unwrap_or_default()),
-        Split::CrossStitchTrans => should_split(mem.deref(&pd.has_parry).unwrap_or_default()),
+        Split::PhantomTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.defeated_phantom).unwrap_or_default())
+        }
+        Split::CrossStitchTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_parry).unwrap_or_default())
+        }
         Split::TrailsEndTrans => {
             should_split(scenes.old == "Shadow_24" && scenes.current == "Shadow_19")
         }
@@ -2119,7 +2137,9 @@ pub fn transition_splits(
         Split::EnterFirstSinner => {
             should_split(scenes.old == "Slab_10c" && scenes.current == "Slab_10b")
         }
-        Split::RuneRageTrans => should_split(mem.deref(&pd.has_silk_bomb).unwrap_or_default()),
+        Split::RuneRageTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_silk_bomb).unwrap_or_default())
+        }
         // endregion: TheSlab
 
         // region: MountFay
@@ -2133,7 +2153,7 @@ pub fn transition_splits(
             should_split(scenes.old == "Peak_01" && scenes.current == "Peak_07")
         }
         Split::FaydownCloakTrans => {
-            should_split(mem.deref(&pd.has_double_jump).unwrap_or_default())
+            should_split(scenes.changed() && mem.deref(&pd.has_double_jump).unwrap_or_default())
         }
         // endregion: MountFay
 
@@ -2147,8 +2167,10 @@ pub fn transition_splits(
             should_split(scenes.old == "Coral_35b" && scenes.current == "Coral_29")
         }
         Split::RagingConchflyTrans => should_split(
-            mem.deref(&pd.defeated_coral_driller_solo)
-                .unwrap_or_default(),
+            scenes.changed()
+                && mem
+                    .deref(&pd.defeated_coral_driller_solo)
+                    .unwrap_or_default(),
         ),
         // endregion: SandsOfKarak
 
@@ -2188,10 +2210,14 @@ pub fn transition_splits(
                 || scenes.old == "Library_04")
                 && scenes.current == "Song_Enclave",
         ),
-        Split::TrobbioTrans => should_split(mem.deref(&pd.defeated_trobbio).unwrap_or_default()),
+        Split::TrobbioTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.defeated_trobbio).unwrap_or_default())
+        }
         Split::TormentedTrobbioTrans => should_split(
-            mem.deref(&pd.defeated_tormented_trobbio)
-                .unwrap_or_default(),
+            scenes.changed()
+                && mem
+                    .deref(&pd.defeated_tormented_trobbio)
+                    .unwrap_or_default(),
         ),
 
         // endregion: ChoralChambers
@@ -2276,47 +2302,51 @@ pub fn transition_splits(
         Split::EnterTheCradle => {
             should_split(scenes.old == "Tube_Hub" && scenes.current == "Cradle_01")
         }
-        Split::PaleNailsTrans => {
-            should_split(mem.deref(&pd.has_silk_boss_needle).unwrap_or_default())
-        }
+        Split::PaleNailsTrans => should_split(
+            scenes.changed() && mem.deref(&pd.has_silk_boss_needle).unwrap_or_default(),
+        ),
         // endregion: TheCradle
 
         // region: ThreefoldMelody
-        Split::VaultkeepersMelodyTrans => {
-            should_split(mem.deref(&pd.has_melody_librarian).unwrap_or_default())
-        }
-        Split::ArchitectsMelodyTrans => {
-            should_split(mem.deref(&pd.has_melody_architect).unwrap_or_default())
-        }
-        Split::ConductorsMelodyTrans => {
-            should_split(mem.deref(&pd.has_melody_conductor).unwrap_or_default())
-        }
+        Split::VaultkeepersMelodyTrans => should_split(
+            scenes.changed() && mem.deref(&pd.has_melody_librarian).unwrap_or_default(),
+        ),
+        Split::ArchitectsMelodyTrans => should_split(
+            scenes.changed() && mem.deref(&pd.has_melody_architect).unwrap_or_default(),
+        ),
+        Split::ConductorsMelodyTrans => should_split(
+            scenes.changed() && mem.deref(&pd.has_melody_conductor).unwrap_or_default(),
+        ),
         // endregion: ThreefoldMelody
 
         // region: Crests
-        Split::ReaperCrestTrans => {
-            should_split(mem.deref(&pd.completed_memory_reaper).unwrap_or_default())
-        }
-        Split::WandererCrestTrans => {
-            should_split(mem.deref(&pd.completed_memory_wanderer).unwrap_or_default())
-        }
-        Split::BeastCrestTrans => {
-            should_split(mem.deref(&pd.completed_memory_beast).unwrap_or_default())
-        }
+        Split::ReaperCrestTrans => should_split(
+            scenes.changed() && mem.deref(&pd.completed_memory_reaper).unwrap_or_default(),
+        ),
+        Split::WandererCrestTrans => should_split(
+            scenes.changed() && mem.deref(&pd.completed_memory_wanderer).unwrap_or_default(),
+        ),
+        Split::BeastCrestTrans => should_split(
+            scenes.changed() && mem.deref(&pd.completed_memory_beast).unwrap_or_default(),
+        ),
         Split::ArchitectCrestTrans => should_split(
-            mem.deref(&pd.completed_memory_toolmaster)
-                .unwrap_or_default(),
+            scenes.changed()
+                && mem
+                    .deref(&pd.completed_memory_toolmaster)
+                    .unwrap_or_default(),
         ),
         Split::WitchCrestTrans => should_split(
-            mem.deref(&pd.belltown_doctor_cured_curse)
-                .unwrap_or_default(),
+            scenes.changed()
+                && mem
+                    .deref(&pd.belltown_doctor_cured_curse)
+                    .unwrap_or_default(),
         ),
-        Split::ShamanCrestTrans => {
-            should_split(mem.deref(&pd.completed_memory_shaman).unwrap_or_default())
-        }
-        Split::SylphsongTrans => {
-            should_split(mem.deref(&pd.has_bound_crest_upgrader).unwrap_or_default())
-        }
+        Split::ShamanCrestTrans => should_split(
+            scenes.changed() && mem.deref(&pd.completed_memory_shaman).unwrap_or_default(),
+        ),
+        Split::SylphsongTrans => should_split(
+            scenes.changed() && mem.deref(&pd.has_bound_crest_upgrader).unwrap_or_default(),
+        ),
         // endregion: Crests
 
         // region: Bellways
@@ -2336,10 +2366,12 @@ pub fn transition_splits(
             (scenes.old == "Song_Tower_Destroyed" && scenes.current == "Cog_09_Destroyed")
                 || (scenes.old == "Song_25" && scenes.current == "Cog_10_Destroyed"),
         ),
-        Split::ForebrothersTrans => {
-            should_split(mem.deref(&pd.defeated_dock_foremen).unwrap_or_default())
+        Split::ForebrothersTrans => should_split(
+            scenes.changed() && mem.deref(&pd.defeated_dock_foremen).unwrap_or_default(),
+        ),
+        Split::SilkSoarTrans => {
+            should_split(scenes.changed() && mem.deref(&pd.has_super_jump).unwrap_or_default())
         }
-        Split::SilkSoarTrans => should_split(mem.deref(&pd.has_super_jump).unwrap_or_default()),
         Split::EnterSeth => {
             should_split(scenes.old == "Under_27" && scenes.current == "Shellwood_22")
         }
@@ -2352,9 +2384,9 @@ pub fn transition_splits(
         Split::EnterVerdaniaMemory => {
             should_split(scenes.old == "Clover_01" && scenes.current == "Clover_01b")
         }
-        Split::PalestagTrans => {
-            should_split(mem.deref(&pd.defeated_white_cloverstag).unwrap_or_default())
-        }
+        Split::PalestagTrans => should_split(
+            scenes.changed() && mem.deref(&pd.defeated_white_cloverstag).unwrap_or_default(),
+        ),
         Split::EnterVerdaniaCastle => {
             should_split(scenes.old == "Clover_04b" && scenes.current == "Clover_10")
         }


### PR DESCRIPTION
Fix Crest Transition autosplits, and possibly other "Transition with X" autosplits, by adding `scenes.changed()` in the Crest Transition code as well as a bunch of other places that may have become necessary after the changes in #177 