### PR TITLE
#[link(wasm_import_module = "env")]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: '1.95.0'
+          rust-version: stable
           targets: wasm32-unknown-unknown
 
       - name: Install Target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "asr"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/asr?branch=split-index#c15a8690ba5aabed95ed150973e188e4851e2dec"
+source = "git+https://github.com/AlexKnauth/asr?branch=split-index#4732a4c1c12ef292b10c17d32e4343c2908951f3"
 dependencies = [
  "arrayvec",
  "asr-derive",
@@ -24,7 +24,7 @@ dependencies = [
 [[package]]
 name = "asr-derive"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/asr?branch=split-index#c15a8690ba5aabed95ed150973e188e4851e2dec"
+source = "git+https://github.com/AlexKnauth/asr?branch=split-index#4732a4c1c12ef292b10c17d32e4343c2908951f3"
 dependencies = [
  "heck",
  "proc-macro2",


### PR DESCRIPTION
After these changes in Rust 1.96.0:
- https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/#changes-to-webassembly-targets
- https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix

Rust has stopped passing `--allow-undefined` to the linker for WASM targets, causing linker errors like:
```
error: linking with `rust-lld` failed: exit status: 1
```
with `undefined symbol: user_settings_add_title`, `undefined symbol: user_settings_add_choice`, and so on through `undefined symbol: user_settings_add_choice_option`.

Adding `#[link(wasm_import_module = "env")]` should fix those linker errors.