### PR TITLE
Fix tool autosplits when IsUnlocked is false

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -900,9 +900,13 @@ pub fn find_tool(tool_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> O
             .read_into_slice(p_string + mem.string_list_offsets.string_contents, buf)
             .ok()?;
 
-        if buf == tool_utf16 {
-            return Some(());
+        if buf != tool_utf16 {
+            continue;
         }
+
+        let is_unlocked: bool = mem.process.read(p_entries + 0x30 + 0x18 * i).ok()?;
+
+        return if is_unlocked { Some(()) } else { None };
     }
 
     None

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -870,7 +870,7 @@ pub fn get_tools_version(mem: &Memory, pd: &PlayerDataPointers) -> Option<i32> {
     mem.deref(&pd.tools_version).ok()
 }
 
-pub fn find_tool(tool_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> Option<()> {
+pub fn find_tool(tool_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> Option<(i32, bool)> {
     asr::print_message("Scanning tools");
     const MAX_TOOL_ID_LENGTH: usize = 32; // The longest seems to be 20 but I rounded up
 
@@ -906,10 +906,18 @@ pub fn find_tool(tool_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> O
 
         let is_unlocked: bool = mem.process.read(p_entries + 0x30 + 0x18 * i).ok()?;
 
-        return if is_unlocked { Some(()) } else { None };
+        return Some((i, is_unlocked));
     }
 
     None
+}
+
+pub fn read_tool(mem: &Memory, pd: &PlayerDataPointers, i: i32) -> Option<bool> {
+    let p_entries = mem.deref::<Address64, _>(&pd.tools_entries).ok()?;
+
+    let is_unlocked: bool = mem.process.read(p_entries + 0x30 + 0x18 * i).ok()?;
+
+    Some(is_unlocked)
 }
 
 // --------------------------------------------------------

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -912,7 +912,7 @@ pub fn find_tool(tool_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> O
     None
 }
 
-pub fn read_tool(mem: &Memory, pd: &PlayerDataPointers, i: i32) -> Option<bool> {
+pub fn read_tool(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<bool> {
     let p_entries = mem.deref::<Address64, _>(&pd.tools_entries).ok()?;
 
     let is_unlocked: bool = mem.process.read(p_entries + 0x30 + 0x18 * i).ok()?;

--- a/src/store.rs
+++ b/src/store.rs
@@ -94,7 +94,7 @@ impl ToolCache {
             }
             self.tool = tool_utf16
         } else if !self.i.is_negative() {
-            if let Some(is_unlocked) = read_tool(e.mem, e.pd, self.i) {
+            if let Some(is_unlocked) = read_tool(self.i, e.mem, e.pd) {
                 self.found = is_unlocked;
             }
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -9,7 +9,7 @@ use asr::{
 
 #[cfg(feature = "split-index")]
 use crate::silksong_memory::get_timer_current_split_index;
-use crate::silksong_memory::{find_tool, get_timer_state, get_tools_version, Env};
+use crate::silksong_memory::{find_tool, get_timer_state, get_tools_version, read_tool, Env};
 
 struct StoreValue<A: 'static> {
     watcher: Watcher<A>,
@@ -43,6 +43,7 @@ impl<A: Clone + Eq> StoreValue<A> {
 pub struct ToolCache {
     version: Option<i32>,
     tool: &'static [u16],
+    i: i32,
     found: bool,
 }
 
@@ -51,6 +52,7 @@ impl ToolCache {
         ToolCache {
             version: None,
             tool: &[],
+            i: -1,
             found: false,
         }
     }
@@ -83,8 +85,18 @@ impl ToolCache {
             return false;
         }
         if self.tool != tool_utf16 {
-            self.found = find_tool(tool_utf16, e.mem, e.pd).is_some();
+            if let Some((i, is_unlocked)) = find_tool(tool_utf16, e.mem, e.pd) {
+                self.i = i;
+                self.found = is_unlocked;
+            } else {
+                self.i = -1;
+                self.found = false;
+            }
             self.tool = tool_utf16
+        } else if !self.i.is_negative() {
+            if let Some(is_unlocked) = read_tool(e.mem, e.pd, self.i) {
+                self.found = is_unlocked;
+            }
         }
         self.found
     }


### PR DESCRIPTION
Fixes #179

- [x] Doesn't split when tool entry exists but `IsUnlocked` is false
- [x] Splits when tool entry exists and `IsUnlocked` is true
- [x] Splits when tool entry has existed with `IsUnlocked` false becoming true