### PR TITLE
Add tool transition splits for Straight Pin and Pimpillo

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -815,7 +815,7 @@ impl SceneStore {
             #[cfg(debug_assertions)]
             asr::print_message(&format!(
                 "curr {} -> next {}",
-                &self.curr_scene_name, &self.next_scene_name
+                self.curr_scene_name, self.next_scene_name
             ));
             true
         } else if self.new_data_curr {
@@ -840,7 +840,7 @@ impl SceneStore {
             #[cfg(debug_assertions)]
             asr::print_message(&format!(
                 "prev {} -> curr {}",
-                &self.prev_scene_name, &self.curr_scene_name
+                self.prev_scene_name, self.curr_scene_name
             ));
             true
         } else if new_scene_load_activation_allowed {
@@ -849,7 +849,7 @@ impl SceneStore {
             #[cfg(debug_assertions)]
             asr::print_message(&format!(
                 "curr {} =? next {}",
-                &self.curr_scene_name, &self.next_scene_name
+                self.curr_scene_name, self.next_scene_name
             ));
             true
         } else {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -3386,7 +3386,7 @@ pub fn splits(
     let a1 = continuous_splits(split, env, store).or_else(|| {
         let scenes = ss.pair();
         let a2 = if !ss.split_this_transition {
-            transition_once_splits(split, &ss, env)
+            transition_once_splits(split, ss, env)
         } else {
             None
         };
@@ -3395,7 +3395,7 @@ pub fn splits(
                 if is_menu(scenes.old) || is_menu(scenes.current) {
                     menu_splits(split, &scenes, env, store)
                 } else {
-                    transition_splits(split, &ss, env, store, ss.split_this_transition)
+                    transition_splits(split, ss, env, store, ss.split_this_transition)
                 }
             } else {
                 None

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2428,8 +2428,10 @@ pub fn transition_splits(
         // endregion: Abyss
 
         // region: Tools
-        Split::StraightPinTrans => should_split(store.has_tool(&utf16!("Straight Pin"), e)),
-        Split::PimpilloTrans => should_split(store.has_tool(&utf16!("Pimpilo"), e)),
+        Split::StraightPinTrans => {
+            should_split(ss.changed() && store.has_tool(&utf16!("Straight Pin"), e))
+        }
+        Split::PimpilloTrans => should_split(ss.changed() && store.has_tool(&utf16!("Pimpilo"), e)),
         // endregion: Tools
 
         // else

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1870,6 +1870,14 @@ pub enum Split {
     ///
     /// Splits when obtaining the Wreath of Purity
     WreathofPurity,
+    /// Straight Pin (Transition)
+    ///
+    /// Splits on the transition after obtaining the Straight Pin
+    StraightPinTrans,
+    /// Pimpillo (Transition)
+    ///
+    /// Splits on the transition after obtaining the Pimpillo
+    PimpilloTrans,
     // endregion: Tools
 }
 
@@ -1931,6 +1939,7 @@ pub fn transition_splits(
     split: &Split,
     ss: &SceneStore,
     e: &Env,
+    store: &mut Store,
     split_this_transition: bool,
 ) -> Option<SplitterAction> {
     let scenes = ss.pair();
@@ -2417,6 +2426,11 @@ pub fn transition_splits(
             should_split(scenes.old == "Abyss_05" && scenes.current == "Last_Dive")
         }
         // endregion: Abyss
+
+        // region: Tools
+        Split::StraightPinTrans => should_split(store.has_tool(&utf16!("Straight Pin"), e)),
+        Split::PimpilloTrans => should_split(store.has_tool(&utf16!("Pimpilo"), e)),
+        // endregion: Tools
 
         // else
         _ => should_split(false),
@@ -3379,7 +3393,7 @@ pub fn splits(
                 if is_menu(scenes.old) || is_menu(scenes.current) {
                     menu_splits(split, &scenes, env, store)
                 } else {
-                    transition_splits(split, &ss, env, ss.split_this_transition)
+                    transition_splits(split, &ss, env, store, ss.split_this_transition)
                 }
             } else {
                 None


### PR DESCRIPTION
Resolves #178. Splits on the transition after obtaining the Straight Pin or Pimpillo respectively.