### PR TITLE
Added Inventory Update System (OnObtainMemoryLocket, OnObtainCogheartPiece, and OnObtainCraftmetal)

### DIFF
--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -632,6 +632,10 @@ declare_pointers!(PlayerDataPointers {
     tools_version: UnityPointer<5> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "Tools", "0x18", "0x4c"]),
     // _instance.playerData.Tools.RuntimeData._entries
     tools_entries: UnityPointer<5> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "Tools", "0x18", "0x18"]),
+    // _instance.playerData.Collectables.RuntimeData._version
+    collectables_version: UnityPointer<5> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "Collectables", "0x18", "0x4c"]),
+    // _instance.playerData.Collectables.RuntimeData._entries
+    collectables_entries: UnityPointer<5> = UnityPointer::new("GameManager", 0, &["_instance", "playerData", "Collectables", "0x18", "0x18"]),
 });
 
 // --------------------------------------------------------
@@ -922,6 +926,130 @@ pub fn read_tool(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<bool> 
 }
 
 // --------------------------------------------------------
+pub fn get_collectables_version(mem: &Memory, pd: &PlayerDataPointers) -> Option<i32> {
+    let version = mem.deref(&pd.collectables_version).ok();
+    version
+}
+
+pub fn find_collectable(item_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> Option<(i32, i32)> {
+    const MAX_ITEM_ID_LENGTH: usize = 32;
+    const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;
+    const COLLECTABLE_KEY_OFFSET: i32 = 0x28;
+    const COLLECTABLE_AMOUNT_OFFSET: i32 = 0x30;
+
+    let buf = &mut [0; MAX_ITEM_ID_LENGTH][..item_utf16.len()];
+
+    let p_entries = mem.deref::<Address64, _>(&pd.collectables_entries).ok()?;
+
+    let len_entries = mem.process.read::<i32>(p_entries + 0x18).ok()?;
+
+    if len_entries > 131 {
+        return None;
+    }
+
+    for i in 0..len_entries {
+        let p_string: Address64 = mem
+            .process
+            .read(p_entries + COLLECTABLE_KEY_OFFSET + COLLECTABLE_ENTRY_STRIDE * i)
+            .ok()?;
+
+        let len_string: i32 = mem
+            .process
+            .read(p_string + mem.string_list_offsets.string_len)
+            .ok()?;
+
+        if len_string != item_utf16.len() as i32 {
+            continue;
+        }
+
+        mem.process
+            .read_into_slice(p_string + mem.string_list_offsets.string_contents, buf)
+            .ok()?;
+
+        if buf != item_utf16 {
+            continue;
+        }
+
+        let amount: i32 = mem
+            .process
+            .read(p_entries + COLLECTABLE_AMOUNT_OFFSET + COLLECTABLE_ENTRY_STRIDE * i)
+            .ok()?;
+
+        return Some((i, amount));
+    }
+
+    None
+}
+
+pub fn read_collectable(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<i32> {
+    const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;
+    const COLLECTABLE_AMOUNT_OFFSET: i32 = 0x30;
+
+    let p_entries = mem.deref::<Address64, _>(&pd.collectables_entries).ok()?;
+
+    let amount: i32 = mem
+        .process
+        .read(p_entries + COLLECTABLE_AMOUNT_OFFSET + COLLECTABLE_ENTRY_STRIDE * i)
+        .ok()?;
+
+    Some(amount)
+}
+
+// DEBUG-ONLY: full dump of every Collectables entry (name + Amount), so callers can notice a
+// change on any item, not just the one a particular Split happens to be watching.
+#[cfg(debug_assertions)]
+pub fn scan_all_collectables(mem: &Memory, pd: &PlayerDataPointers) -> Option<Vec<(String, i32)>> {
+    const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;
+    const COLLECTABLE_KEY_OFFSET: i32 = 0x28;
+    const COLLECTABLE_AMOUNT_OFFSET: i32 = 0x30;
+
+    let p_entries = mem.deref::<Address64, _>(&pd.collectables_entries).ok()?;
+
+    let len_entries = mem.process.read::<i32>(p_entries + 0x18).ok()?;
+
+    if len_entries > 131 {
+        return None;
+    }
+
+    let mut out = Vec::new();
+    for i in 0..len_entries {
+        let p_string: Address64 = mem
+            .process
+            .read(p_entries + COLLECTABLE_KEY_OFFSET + COLLECTABLE_ENTRY_STRIDE * i)
+            .ok()?;
+
+        if p_string.is_null() {
+            continue;
+        }
+
+        let len_string: i32 = mem
+            .process
+            .read(p_string + mem.string_list_offsets.string_len)
+            .ok()?;
+
+        if !(0..2048).contains(&len_string) {
+            continue;
+        }
+
+        let w: Vec<u16> = mem
+            .process
+            .read_vec(p_string + mem.string_list_offsets.string_contents, len_string as usize)
+            .ok()?;
+
+        let Ok(name) = String::from_utf16(&w) else {
+            continue;
+        };
+
+        let amount: i32 = mem
+            .process
+            .read(p_entries + COLLECTABLE_AMOUNT_OFFSET + COLLECTABLE_ENTRY_STRIDE * i)
+            .ok()?;
+
+        out.push((name, amount));
+    }
+
+    Some(out)
+}
 
 pub fn get_timer_state(_: Option<&Env>) -> Option<TimerState> {
     Some(asr::timer::state())

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -928,8 +928,7 @@ pub fn read_tool(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<bool> 
 
 // --------------------------------------------------------
 pub fn get_collectables_version(mem: &Memory, pd: &PlayerDataPointers) -> Option<i32> {
-    let version = mem.deref(&pd.collectables_version).ok();
-    version
+    mem.deref(&pd.collectables_version).ok()
 }
 
 pub fn find_collectable(item_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> Option<(i32, i32)> {
@@ -1077,19 +1076,9 @@ pub fn get_heart_pieces(e: Option<&Env>) -> Option<i32> {
     e?.mem.deref(&e?.pd.heart_pieces).ok()
 }
 
-// Each Collectables item that needs "just increased" detection gets its own dedicated getter
-// like this one, routed through Store::get_i32_pair_bang (see Split::MemoryLocket in splits.rs) -
-// NOT a shared single-slot cache. A shared cache keyed only by item name can't tell two separate
-// occurrences of the same item-based Split apart (e.g. the same collectable split reused later
-// in the list), and ends up comparing against stale history from the wrong occurrence.
+// Each collectable needing "just increased" detection gets its own dedicated getter
 pub fn get_memory_locket_amount(e: Option<&Env>) -> Option<i32> {
     let Env { mem, pd, .. } = e?;
-    // "Memory Locket" is the in-game display name; the Collectables dictionary key is the
-    // internal id "Crest Socket Unlocker" - confirmed against the live debug log.
-    // Not-found means "not picked up yet", i.e. 0 - NOT None/unknown. An item with no dictionary
-    // entry until first pickup would otherwise never get a valid `old` baseline to compare
-    // against: the first successful read would BE the pickup itself, and a Pair's first-ever
-    // observation always baselines with no history, so `increased()` could never fire.
     let amount = find_collectable(&utf16!("Crest Socket Unlocker"), mem, pd)
         .map(|(_, amount)| amount)
         .unwrap_or(0);

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -980,8 +980,6 @@ pub fn find_collectable(
     None
 }
 
-// DEBUG-ONLY: full dump of every Collectables entry (name + Amount), so callers can notice a
-// change on any item, not just the one a particular Split happens to be watching.
 #[cfg(debug_assertions)]
 pub fn scan_all_collectables(mem: &Memory, pd: &PlayerDataPointers) -> Option<Vec<(String, i32)>> {
     const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -14,6 +14,7 @@ use asr::{
     Address64, Process,
 };
 use bytemuck::CheckedBitPattern;
+use utf16_lit::utf16;
 
 // --------------------------------------------------------
 
@@ -1074,6 +1075,19 @@ pub fn get_max_health_base(e: Option<&Env>) -> Option<i32> {
 
 pub fn get_heart_pieces(e: Option<&Env>) -> Option<i32> {
     e?.mem.deref(&e?.pd.heart_pieces).ok()
+}
+
+// Each Collectables item that needs "just increased" detection gets its own dedicated getter
+// like this one, routed through Store::get_i32_pair_bang (see Split::MemoryLocket in splits.rs) -
+// NOT a shared single-slot cache. A shared cache keyed only by item name can't tell two separate
+// occurrences of the same item-based Split apart (e.g. the same collectable split reused later
+// in the list), and ends up comparing against stale history from the wrong occurrence.
+pub fn get_memory_locket_amount(e: Option<&Env>) -> Option<i32> {
+    let Env { mem, pd, .. } = e?;
+    // "Memory Locket" is the in-game display name; the Collectables dictionary key is the
+    // internal id "Crest Socket Unlocker" - confirmed against the live debug log.
+    let (_, amount) = find_collectable(&utf16!("Crest Socket Unlocker"), mem, pd)?;
+    Some(amount)
 }
 
 pub fn get_silk_max(e: Option<&Env>) -> Option<i32> {

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -14,7 +14,6 @@ use asr::{
     Address64, Process,
 };
 use bytemuck::CheckedBitPattern;
-use utf16_lit::utf16;
 
 // --------------------------------------------------------
 
@@ -927,10 +926,6 @@ pub fn read_tool(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<bool> 
 }
 
 // --------------------------------------------------------
-pub fn get_collectables_version(mem: &Memory, pd: &PlayerDataPointers) -> Option<i32> {
-    mem.deref(&pd.collectables_version).ok()
-}
-
 pub fn find_collectable(item_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> Option<(i32, i32)> {
     const MAX_ITEM_ID_LENGTH: usize = 32;
     const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;
@@ -979,20 +974,6 @@ pub fn find_collectable(item_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointer
     }
 
     None
-}
-
-pub fn read_collectable(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<i32> {
-    const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;
-    const COLLECTABLE_AMOUNT_OFFSET: i32 = 0x30;
-
-    let p_entries = mem.deref::<Address64, _>(&pd.collectables_entries).ok()?;
-
-    let amount: i32 = mem
-        .process
-        .read(p_entries + COLLECTABLE_AMOUNT_OFFSET + COLLECTABLE_ENTRY_STRIDE * i)
-        .ok()?;
-
-    Some(amount)
 }
 
 // DEBUG-ONLY: full dump of every Collectables entry (name + Amount), so callers can notice a
@@ -1074,15 +1055,6 @@ pub fn get_max_health_base(e: Option<&Env>) -> Option<i32> {
 
 pub fn get_heart_pieces(e: Option<&Env>) -> Option<i32> {
     e?.mem.deref(&e?.pd.heart_pieces).ok()
-}
-
-// Each collectable needing "just increased" detection gets its own dedicated getter
-pub fn get_memory_locket_amount(e: Option<&Env>) -> Option<i32> {
-    let Env { mem, pd, .. } = e?;
-    let amount = find_collectable(&utf16!("Crest Socket Unlocker"), mem, pd)
-        .map(|(_, amount)| amount)
-        .unwrap_or(0);
-    Some(amount)
 }
 
 pub fn get_silk_max(e: Option<&Env>) -> Option<i32> {

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -926,7 +926,11 @@ pub fn read_tool(i: i32, mem: &Memory, pd: &PlayerDataPointers) -> Option<bool> 
 }
 
 // --------------------------------------------------------
-pub fn find_collectable(item_utf16: &[u16], mem: &Memory, pd: &PlayerDataPointers) -> Option<(i32, i32)> {
+pub fn find_collectable(
+    item_utf16: &[u16],
+    mem: &Memory,
+    pd: &PlayerDataPointers,
+) -> Option<(i32, i32)> {
     const MAX_ITEM_ID_LENGTH: usize = 32;
     const COLLECTABLE_ENTRY_STRIDE: i32 = 0x20;
     const COLLECTABLE_KEY_OFFSET: i32 = 0x28;
@@ -1014,7 +1018,10 @@ pub fn scan_all_collectables(mem: &Memory, pd: &PlayerDataPointers) -> Option<Ve
 
         let w: Vec<u16> = mem
             .process
-            .read_vec(p_string + mem.string_list_offsets.string_contents, len_string as usize)
+            .read_vec(
+                p_string + mem.string_list_offsets.string_contents,
+                len_string as usize,
+            )
             .ok()?;
 
         let Ok(name) = String::from_utf16(&w) else {

--- a/src/silksong_memory.rs
+++ b/src/silksong_memory.rs
@@ -1086,7 +1086,13 @@ pub fn get_memory_locket_amount(e: Option<&Env>) -> Option<i32> {
     let Env { mem, pd, .. } = e?;
     // "Memory Locket" is the in-game display name; the Collectables dictionary key is the
     // internal id "Crest Socket Unlocker" - confirmed against the live debug log.
-    let (_, amount) = find_collectable(&utf16!("Crest Socket Unlocker"), mem, pd)?;
+    // Not-found means "not picked up yet", i.e. 0 - NOT None/unknown. An item with no dictionary
+    // entry until first pickup would otherwise never get a valid `old` baseline to compare
+    // against: the first successful read would BE the pickup itself, and a Pair's first-ever
+    // observation always baselines with no history, so `increased()` could never fire.
+    let amount = find_collectable(&utf16!("Crest Socket Unlocker"), mem, pd)
+        .map(|(_, amount)| amount)
+        .unwrap_or(0);
     Some(amount)
 }
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -9,7 +9,7 @@ use utf16_lit::utf16;
 use crate::{
     silksong_memory::{
         get_at_bench, get_health, get_heart_pieces, get_is_maggoted, get_max_health_base,
-        get_memory_locket_amount, get_respawn_scene, get_silk_max, get_silk_spool_parts,
+        get_respawn_scene, get_silk_max, get_silk_spool_parts,
         is_discontinuity_scene, is_menu, Env, SceneStore, CINEMATIC_STAG_TRAVEL,
         DEATH_RESPAWN_MARKER_INIT, GAME_STATE_PLAYING, MENU_TITLE, NON_MENU_GAME_STATES,
         OPENING_SCENES,
@@ -1918,6 +1918,16 @@ pub enum Split {
     ///
     /// Splits when obtaining a Memory Locket
     OnObtainMemoryLocket,
+
+    /// Cogheart Piece (Obtain)
+    ///
+    /// Splits when obtaining a Cogheart Piece
+    OnObtainCogheartPiece,
+
+    /// Crafmetal (Obtain)
+    ///
+    /// Splits when obtaining a Crafmetal
+    OnObtainCraftmetal,
     // endregion: Collectables
 }
 
@@ -2559,16 +2569,26 @@ fn bench_split(store: &mut Store, e: &Env) -> bool {
         .is_some_and(|p| p.changed_to(&true))
 }
 
+fn obtained_collectable(store: &mut Store, item_utf16: &'static [u16], e: &Env) -> bool {
+    store
+        .get_collectable_pair(item_utf16, Some(e))
+        .is_some_and(|p| p.increased())
+}
+
 // Delta ("just increased") splits on inventory data - kept outside continuous_splits' game_state
 // gate, since item-get popups can pause the game for a tick and would otherwise lose the change.
 pub fn on_obtain_item_splits(split: &Split, e: &Env, store: &mut Store) -> Option<SplitterAction> {
     match split {
         // region: Collectables
-        Split::OnObtainMemoryLocket => should_split(
-            store
-                .get_i32_pair_bang("memory_locket_amount", &get_memory_locket_amount, Some(e))
-                .is_some_and(|p| p.increased()),
-        ),
+        Split::OnObtainMemoryLocket => {
+            should_split(obtained_collectable(store, &utf16!("Crest Socket Unlocker"), e))
+        }
+        Split::OnObtainCogheartPiece => {
+            should_split(obtained_collectable(store, &utf16!("Cog Heart Pieces"), e))
+        }
+        Split::OnObtainCraftmetal => {
+            should_split(obtained_collectable(store, &utf16!("Tool Metal"), e))
+        }
         // endregion: Collectables
         _ => None,
     }

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1917,7 +1917,7 @@ pub enum Split {
     /// Memory Locket (Obtain)
     ///
     /// Splits when obtaining a Memory Locket
-    MemoryLocket,
+    OnObtainMemoryLocket,
     // endregion: Collectables
 }
 
@@ -2559,16 +2559,12 @@ fn bench_split(store: &mut Store, e: &Env) -> bool {
         .is_some_and(|p| p.changed_to(&true))
 }
 
-/// Splits based on a delta ("just increased") over player-inventory data - e.g. Collectables
-/// pickups. These do NOT go through continuous_splits' game_state gate: item-get popups can
-/// pause the game for a tick right when the pickup registers, and Store's Pair-watcher
-/// "interested" bookkeeping would otherwise get pruned and rebaselined during that pause,
-/// silently losing the exact transition being tracked. Add new OnObtainX-style splits here,
-/// not in continuous_splits, so they don't need this gate worked around by hand each time.
+// Delta ("just increased") splits on inventory data - kept outside continuous_splits' game_state
+// gate, since item-get popups can pause the game for a tick and would otherwise lose the change.
 pub fn on_obtain_item_splits(split: &Split, e: &Env, store: &mut Store) -> Option<SplitterAction> {
     match split {
         // region: Collectables
-        Split::MemoryLocket => should_split(
+        Split::OnObtainMemoryLocket => should_split(
             store
                 .get_i32_pair_bang("memory_locket_amount", &get_memory_locket_amount, Some(e))
                 .is_some_and(|p| p.increased()),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1911,6 +1911,13 @@ pub enum Split {
     /// Splits on the transition after obtaining the Pimpillo
     PimpilloTrans,
     // endregion: Tools
+
+    // region: Collectables
+    /// Memory Locket (Obtain)
+    ///
+    /// Splits when obtaining a Memory Locket
+    MemoryLocket,
+    // endregion: Collectables
 }
 
 impl StoreWidget for Split {
@@ -3428,6 +3435,12 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<Sp
         Split::SilkspeedAnklets => should_split(store.has_tool(&utf16!("Sprintmaster"), e)),
         Split::ThiefsMark => should_split(store.has_tool(&utf16!("Thief Charm"), e)),
         // endregion Tools
+
+        // region: Collectables
+        Split::MemoryLocket => {
+            should_split(store.collectable_increased(&utf16!("Crest Socket Unlocker"), e))
+        }
+        // endregion: Collectables
 
         // else
         _ => should_split(false),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -2559,6 +2559,25 @@ fn bench_split(store: &mut Store, e: &Env) -> bool {
         .is_some_and(|p| p.changed_to(&true))
 }
 
+/// Splits based on a delta ("just increased") over player-inventory data - e.g. Collectables
+/// pickups. These do NOT go through continuous_splits' game_state gate: item-get popups can
+/// pause the game for a tick right when the pickup registers, and Store's Pair-watcher
+/// "interested" bookkeeping would otherwise get pruned and rebaselined during that pause,
+/// silently losing the exact transition being tracked. Add new OnObtainX-style splits here,
+/// not in continuous_splits, so they don't need this gate worked around by hand each time.
+pub fn on_obtain_item_splits(split: &Split, e: &Env, store: &mut Store) -> Option<SplitterAction> {
+    match split {
+        // region: Collectables
+        Split::MemoryLocket => should_split(
+            store
+                .get_i32_pair_bang("memory_locket_amount", &get_memory_locket_amount, Some(e))
+                .is_some_and(|p| p.increased()),
+        ),
+        // endregion: Collectables
+        _ => None,
+    }
+}
+
 pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<SplitterAction> {
     let Env { mem, gm, pd } = e;
     let game_state: i32 = mem.deref(&gm.game_state).unwrap_or_default();
@@ -3437,14 +3456,6 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<Sp
         Split::ThiefsMark => should_split(store.has_tool(&utf16!("Thief Charm"), e)),
         // endregion Tools
 
-        // region: Collectables
-        Split::MemoryLocket => should_split(
-            store
-                .get_i32_pair_bang("memory_locket_amount", &get_memory_locket_amount, Some(e))
-                .is_some_and(|p| p.increased()),
-        ),
-        // endregion: Collectables
-
         // else
         _ => should_split(false),
     }
@@ -3457,23 +3468,25 @@ pub fn splits(
     ss: &mut SceneStore,
     store: &mut Store,
 ) -> Option<SplitterAction> {
-    let a1 = continuous_splits(split, env, store).or_else(|| {
-        let scenes = ss.pair();
-        let a2 = if !ss.split_this_transition {
-            transition_once_splits(split, ss, env)
-        } else {
-            None
-        };
-        a2.or_else(|| {
-            if trans_now {
-                if is_menu(scenes.old) || is_menu(scenes.current) {
-                    menu_splits(split, &scenes, env, store)
-                } else {
-                    transition_splits(split, ss, env, store, ss.split_this_transition)
-                }
+    let a1 = on_obtain_item_splits(split, env, store).or_else(|| {
+        continuous_splits(split, env, store).or_else(|| {
+            let scenes = ss.pair();
+            let a2 = if !ss.split_this_transition {
+                transition_once_splits(split, ss, env)
             } else {
                 None
-            }
+            };
+            a2.or_else(|| {
+                if trans_now {
+                    if is_menu(scenes.old) || is_menu(scenes.current) {
+                        menu_splits(split, &scenes, env, store)
+                    } else {
+                        transition_splits(split, ss, env, store, ss.split_this_transition)
+                    }
+                } else {
+                    None
+                }
+            })
         })
     });
     if a1.is_some() {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -9,9 +9,10 @@ use utf16_lit::utf16;
 use crate::{
     silksong_memory::{
         get_at_bench, get_health, get_heart_pieces, get_is_maggoted, get_max_health_base,
-        get_respawn_scene, get_silk_max, get_silk_spool_parts, is_discontinuity_scene, is_menu,
-        Env, SceneStore, CINEMATIC_STAG_TRAVEL, DEATH_RESPAWN_MARKER_INIT, GAME_STATE_PLAYING,
-        MENU_TITLE, NON_MENU_GAME_STATES, OPENING_SCENES,
+        get_memory_locket_amount, get_respawn_scene, get_silk_max, get_silk_spool_parts,
+        is_discontinuity_scene, is_menu, Env, SceneStore, CINEMATIC_STAG_TRAVEL,
+        DEATH_RESPAWN_MARKER_INIT, GAME_STATE_PLAYING, MENU_TITLE, NON_MENU_GAME_STATES,
+        OPENING_SCENES,
     },
     store::Store,
     timer::{reached_up_to_split, should_split, SplitterAction},
@@ -3437,9 +3438,11 @@ pub fn continuous_splits(split: &Split, e: &Env, store: &mut Store) -> Option<Sp
         // endregion Tools
 
         // region: Collectables
-        Split::MemoryLocket => {
-            should_split(store.collectable_increased(&utf16!("Crest Socket Unlocker"), e))
-        }
+        Split::MemoryLocket => should_split(
+            store
+                .get_i32_pair_bang("memory_locket_amount", &get_memory_locket_amount, Some(e))
+                .is_some_and(|p| p.increased()),
+        ),
         // endregion: Collectables
 
         // else

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -9,10 +9,9 @@ use utf16_lit::utf16;
 use crate::{
     silksong_memory::{
         get_at_bench, get_health, get_heart_pieces, get_is_maggoted, get_max_health_base,
-        get_respawn_scene, get_silk_max, get_silk_spool_parts,
-        is_discontinuity_scene, is_menu, Env, SceneStore, CINEMATIC_STAG_TRAVEL,
-        DEATH_RESPAWN_MARKER_INIT, GAME_STATE_PLAYING, MENU_TITLE, NON_MENU_GAME_STATES,
-        OPENING_SCENES,
+        get_respawn_scene, get_silk_max, get_silk_spool_parts, is_discontinuity_scene, is_menu,
+        Env, SceneStore, CINEMATIC_STAG_TRAVEL, DEATH_RESPAWN_MARKER_INIT, GAME_STATE_PLAYING,
+        MENU_TITLE, NON_MENU_GAME_STATES, OPENING_SCENES,
     },
     store::Store,
     timer::{reached_up_to_split, should_split, SplitterAction},
@@ -2580,9 +2579,11 @@ fn obtained_collectable(store: &mut Store, item_utf16: &'static [u16], e: &Env) 
 pub fn on_obtain_item_splits(split: &Split, e: &Env, store: &mut Store) -> Option<SplitterAction> {
     match split {
         // region: Collectables
-        Split::OnObtainMemoryLocket => {
-            should_split(obtained_collectable(store, &utf16!("Crest Socket Unlocker"), e))
-        }
+        Split::OnObtainMemoryLocket => should_split(obtained_collectable(
+            store,
+            &utf16!("Crest Socket Unlocker"),
+            e,
+        )),
         Split::OnObtainCogheartPiece => {
             should_split(obtained_collectable(store, &utf16!("Cog Heart Pieces"), e))
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -215,7 +215,7 @@ impl Store {
     // item whose amount changed since the last scan - independent of any active Split.
     #[cfg(debug_assertions)]
     fn log_collectable_changes(&mut self, e: Option<&Env>) {
-        let Some(Env { pd, mem, .. }) = e else {
+        let Some(Env { pd, mem, gm }) = e else {
             return;
         };
         let new_version: Option<i32> = mem.deref(&pd.collectables_version).ok();
@@ -228,6 +228,8 @@ impl Store {
             return;
         };
 
+        let game_state: Option<i32> = mem.deref(&gm.game_state).ok();
+
         for (name, amount) in &entries {
             let prev = self
                 .collectables_log_snapshot
@@ -237,8 +239,8 @@ impl Store {
             if amount != &prev {
                 let verb = if *amount > prev { "gained" } else { "lost" };
                 asr::print_message(&format!(
-                    "Collectable \"{}\" {}: {} -> {}",
-                    name, verb, prev, amount
+                    "Collectable \"{}\" {}: {} -> {} (game_state={:?})",
+                    name, verb, prev, amount, game_state
                 ));
             }
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -13,7 +13,9 @@ use asr::{
 use crate::silksong_memory::get_timer_current_split_index;
 #[cfg(debug_assertions)]
 use crate::silksong_memory::scan_all_collectables;
-use crate::silksong_memory::{find_collectable, find_tool, get_timer_state, get_tools_version, read_tool, Env};
+use crate::silksong_memory::{
+    find_collectable, find_tool, get_timer_state, get_tools_version, read_tool, Env,
+};
 
 struct StoreValue<A: 'static> {
     watcher: Watcher<A>,
@@ -207,7 +209,11 @@ impl Store {
         self.tools.has_tool(tool_utf16, e)
     }
 
-    pub fn get_collectable_pair(&mut self, item_utf16: &'static [u16], e: Option<&Env>) -> Option<Pair<i32>> {
+    pub fn get_collectable_pair(
+        &mut self,
+        item_utf16: &'static [u16],
+        e: Option<&Env>,
+    ) -> Option<Pair<i32>> {
         let entry = self.collectables.entry(item_utf16).or_insert_with(|| {
             let mut watcher = Watcher::new();
             if let Some(Env { mem, pd, .. }) = e {

--- a/src/store.rs
+++ b/src/store.rs
@@ -109,11 +109,6 @@ impl ToolCache {
     }
 }
 
-// Plain current-value cache, shaped like ToolCache - only for "currently own > 0" style checks.
-// Do NOT add increase/delta ("just picked up") tracking here: a single slot keyed only by item
-// name can't distinguish two separate occurrences of the same item-based Split later in a run
-// (see get_memory_locket_amount in silksong_memory.rs for that instead, routed through
-// Store::get_i32_pair_bang like OnObtainMaskShard).
 pub struct CollectableCache {
     version: Option<i32>,
     item: &'static [u16],
@@ -185,8 +180,7 @@ pub struct Store {
     strings: BTreeMap<&'static str, StoreValue<String>>,
     tools: ToolCache,
     collectables: CollectableCache,
-    // DEBUG-ONLY: last-seen (name -> amount) for every Collectables entry, so any change can be
-    // logged regardless of which Split (if any) is currently active. See `log_collectable_changes`.
+    // DEBUG-ONLY: last-seen amount per Collectables entry, for log_collectable_changes below.
     #[cfg(debug_assertions)]
     collectables_log_version: Option<i32>,
     #[cfg(debug_assertions)]
@@ -211,8 +205,7 @@ impl Store {
         }
     }
 
-    // DEBUG-ONLY: on a Collectables version bump, scans every entry and prints one line per
-    // item whose amount changed since the last scan - independent of any active Split.
+    // DEBUG-ONLY: logs every Collectables amount change, independent of the active Split.
     #[cfg(debug_assertions)]
     fn log_collectable_changes(&mut self, e: Option<&Env>) {
         let Some(Env { pd, mem, gm }) = e else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -147,7 +147,6 @@ impl Store {
         }
     }
 
-    // DEBUG-ONLY: logs every Collectables amount change, independent of the active Split.
     #[cfg(debug_assertions)]
     fn log_collectable_changes(&mut self, e: Option<&Env>) {
         let Some(Env { pd, mem, gm }) = e else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,3 +1,5 @@
+#[cfg(debug_assertions)]
+use alloc::format;
 use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
@@ -9,7 +11,12 @@ use asr::{
 
 #[cfg(feature = "split-index")]
 use crate::silksong_memory::get_timer_current_split_index;
-use crate::silksong_memory::{find_tool, get_timer_state, get_tools_version, read_tool, Env};
+#[cfg(debug_assertions)]
+use crate::silksong_memory::scan_all_collectables;
+use crate::silksong_memory::{
+    find_collectable, find_tool, get_collectables_version, get_timer_state, get_tools_version,
+    read_collectable, read_tool, Env,
+};
 
 struct StoreValue<A: 'static> {
     watcher: Watcher<A>,
@@ -102,6 +109,111 @@ impl ToolCache {
     }
 }
 
+pub struct CollectableCache {
+    version: Option<i32>,
+    // The item name this cache's amount/prev_amount history belongs to. Only changes when the
+    // caller queries a different item - a Collectables version bump does NOT clear this, so
+    // history survives across re-scans (see `stale`).
+    item: &'static [u16],
+    // Set on a Collectables version bump (or construction): the cached index `i` may no longer
+    // be valid and must be re-derived via a full find_collectable scan before it's trusted again.
+    stale: bool,
+    i: i32,
+    prev_amount: i32,
+    amount: i32,
+}
+
+impl CollectableCache {
+    fn new() -> Self {
+        CollectableCache {
+            version: None,
+            item: &[],
+            stale: true,
+            i: -1,
+            prev_amount: 0,
+            amount: 0,
+        }
+    }
+
+    fn update_version(&mut self, e: Option<&Env>) {
+        match e {
+            None => {
+                self.version = None;
+                self.stale = true;
+            }
+            Some(Env { pd, mem, .. }) => {
+                let new = get_collectables_version(mem, pd);
+                if self.version != new {
+                    self.version = new;
+                    self.stale = true;
+                }
+            }
+        }
+    }
+
+    pub fn update_validity(&mut self, e: Option<&Env>) {
+        if !self.item.is_empty() {
+            self.update_version(e)
+        }
+    }
+
+    /// Returns the current amount owned for `item_utf16`. Also updates the previous-amount
+    /// history used by `increased`, so calling this directly instead of through `increased`
+    /// still keeps that history correct.
+    pub fn get_amount(&mut self, item_utf16: &'static [u16], e: &Env) -> i32 {
+        self.update_version(Some(e));
+        let item_switched = self.item != item_utf16;
+        self.prev_amount = self.amount;
+        if item_switched {
+            self.item = item_utf16;
+            self.stale = true;
+        }
+        if self.version.is_none() {
+            self.i = -1;
+            self.amount = 0;
+        } else if self.stale {
+            if let Some((i, amount)) = find_collectable(item_utf16, e.mem, e.pd) {
+                self.i = i;
+                self.amount = amount;
+            } else {
+                self.i = -1;
+                self.amount = 0;
+            }
+            self.stale = false;
+        } else if !self.i.is_negative() {
+            if let Some(amount) = read_collectable(self.i, e.mem, e.pd) {
+                self.amount = amount;
+            }
+        }
+        if item_switched {
+            // No meaningful history when comparing against a different item's amount.
+            self.prev_amount = self.amount;
+        }
+        #[cfg(debug_assertions)]
+        if self.amount != self.prev_amount {
+            let name = String::from_utf16_lossy(item_utf16);
+            let verb = if self.amount > self.prev_amount {
+                "gained"
+            } else {
+                "lost"
+            };
+            asr::print_message(&format!(
+                "Collectable \"{}\" {}: {} -> {}",
+                name, verb, self.prev_amount, self.amount
+            ));
+        }
+        self.amount
+    }
+
+    /// True on the tick the amount owned for `item_utf16` goes up (e.g. picking up a
+    /// Collectable), false otherwise - mirrors `Pair::increased()` for a value that isn't
+    /// otherwise tracked via `Store`'s generic `i32s` watcher map.
+    pub fn increased(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
+        self.get_amount(item_utf16, e);
+        self.amount > self.prev_amount
+    }
+}
+
 pub struct Store {
     timer_state: StoreValue<TimerState>,
     #[cfg(feature = "split-index")]
@@ -110,6 +222,13 @@ pub struct Store {
     i32s: BTreeMap<&'static str, StoreValue<i32>>,
     strings: BTreeMap<&'static str, StoreValue<String>>,
     tools: ToolCache,
+    collectables: CollectableCache,
+    // DEBUG-ONLY: last-seen (name -> amount) for every Collectables entry, so any change can be
+    // logged regardless of which Split (if any) is currently active. See `log_collectable_changes`.
+    #[cfg(debug_assertions)]
+    collectables_log_version: Option<i32>,
+    #[cfg(debug_assertions)]
+    collectables_log_snapshot: BTreeMap<String, i32>,
 }
 
 impl Store {
@@ -122,7 +241,47 @@ impl Store {
             i32s: BTreeMap::new(),
             strings: BTreeMap::new(),
             tools: ToolCache::new(),
+            collectables: CollectableCache::new(),
+            #[cfg(debug_assertions)]
+            collectables_log_version: None,
+            #[cfg(debug_assertions)]
+            collectables_log_snapshot: BTreeMap::new(),
         }
+    }
+
+    // DEBUG-ONLY: on a Collectables version bump, scans every entry and prints one line per
+    // item whose amount changed since the last scan - independent of any active Split.
+    #[cfg(debug_assertions)]
+    fn log_collectable_changes(&mut self, e: Option<&Env>) {
+        let Some(Env { pd, mem, .. }) = e else {
+            return;
+        };
+        let new_version: Option<i32> = mem.deref(&pd.collectables_version).ok();
+        if self.collectables_log_version == new_version {
+            return;
+        }
+        self.collectables_log_version = new_version;
+
+        let Some(entries) = scan_all_collectables(mem, pd) else {
+            return;
+        };
+
+        for (name, amount) in &entries {
+            let prev = self
+                .collectables_log_snapshot
+                .get(name)
+                .copied()
+                .unwrap_or(0);
+            if amount != &prev {
+                let verb = if *amount > prev { "gained" } else { "lost" };
+                asr::print_message(&format!(
+                    "Collectable \"{}\" {}: {} -> {}",
+                    name, verb, prev, amount
+                ));
+            }
+        }
+
+        self.collectables_log_snapshot = entries.into_iter().collect();
     }
 
     pub fn get_timer_state_pair(&mut self) -> Option<Pair<TimerState>> {
@@ -149,6 +308,18 @@ impl Store {
 
     pub fn has_tool(&mut self, tool_utf16: &'static [u16], e: &Env) -> bool {
         self.tools.has_tool(tool_utf16, e)
+    }
+
+    pub fn get_collectable_amount(&mut self, item_utf16: &'static [u16], e: &Env) -> i32 {
+        self.collectables.get_amount(item_utf16, e)
+    }
+
+    pub fn has_collectable(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
+        self.collectables.get_amount(item_utf16, e) > 0
+    }
+
+    pub fn collectable_increased(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
+        self.collectables.increased(item_utf16, e)
     }
 
     pub fn get_bool_pair(&mut self, key: &str) -> Option<Pair<bool>> {
@@ -213,6 +384,9 @@ impl Store {
         #[cfg(feature = "split-index")]
         self.split_index.update(env);
         self.tools.update_validity(env);
+        self.collectables.update_validity(env);
+        #[cfg(debug_assertions)]
+        self.log_collectable_changes(env);
         for v in self.bools.values_mut() {
             if v.update(env) {
                 v.interested = false;

--- a/src/store.rs
+++ b/src/store.rs
@@ -13,10 +13,7 @@ use asr::{
 use crate::silksong_memory::get_timer_current_split_index;
 #[cfg(debug_assertions)]
 use crate::silksong_memory::scan_all_collectables;
-use crate::silksong_memory::{
-    find_collectable, find_tool, get_collectables_version, get_timer_state, get_tools_version,
-    read_collectable, read_tool, Env,
-};
+use crate::silksong_memory::{find_collectable, find_tool, get_timer_state, get_tools_version, read_tool, Env};
 
 struct StoreValue<A: 'static> {
     watcher: Watcher<A>,
@@ -109,66 +106,9 @@ impl ToolCache {
     }
 }
 
-pub struct CollectableCache {
-    version: Option<i32>,
-    item: &'static [u16],
-    i: i32,
-    amount: i32,
-}
-
-impl CollectableCache {
-    fn new() -> Self {
-        CollectableCache {
-            version: None,
-            item: &[],
-            i: -1,
-            amount: 0,
-        }
-    }
-
-    fn update_version(&mut self, e: Option<&Env>) {
-        match e {
-            None => {
-                self.version = None;
-                self.item = &[]
-            }
-            Some(Env { pd, mem, .. }) => {
-                let new = get_collectables_version(mem, pd);
-                if self.version != new {
-                    self.version = new;
-                    self.item = &[]
-                }
-            }
-        }
-    }
-
-    pub fn update_validity(&mut self, e: Option<&Env>) {
-        if !self.item.is_empty() {
-            self.update_version(e)
-        }
-    }
-
-    pub fn get_amount(&mut self, item_utf16: &'static [u16], e: &Env) -> i32 {
-        self.update_version(Some(e));
-        if self.version.is_none() {
-            return 0;
-        }
-        if self.item != item_utf16 {
-            if let Some((i, amount)) = find_collectable(item_utf16, e.mem, e.pd) {
-                self.i = i;
-                self.amount = amount;
-            } else {
-                self.i = -1;
-                self.amount = 0;
-            }
-            self.item = item_utf16
-        } else if !self.i.is_negative() {
-            if let Some(amount) = read_collectable(self.i, e.mem, e.pd) {
-                self.amount = amount;
-            }
-        }
-        self.amount
-    }
+struct CollectableWatcher {
+    watcher: Watcher<i32>,
+    interested: bool,
 }
 
 pub struct Store {
@@ -179,7 +119,7 @@ pub struct Store {
     i32s: BTreeMap<&'static str, StoreValue<i32>>,
     strings: BTreeMap<&'static str, StoreValue<String>>,
     tools: ToolCache,
-    collectables: CollectableCache,
+    collectables: BTreeMap<&'static [u16], CollectableWatcher>,
     // DEBUG-ONLY: last-seen amount per Collectables entry, for log_collectable_changes below.
     #[cfg(debug_assertions)]
     collectables_log_version: Option<i32>,
@@ -197,7 +137,7 @@ impl Store {
             i32s: BTreeMap::new(),
             strings: BTreeMap::new(),
             tools: ToolCache::new(),
-            collectables: CollectableCache::new(),
+            collectables: BTreeMap::new(),
             #[cfg(debug_assertions)]
             collectables_log_version: None,
             #[cfg(debug_assertions)]
@@ -267,12 +207,21 @@ impl Store {
         self.tools.has_tool(tool_utf16, e)
     }
 
-    pub fn get_collectable_amount(&mut self, item_utf16: &'static [u16], e: &Env) -> i32 {
-        self.collectables.get_amount(item_utf16, e)
-    }
-
-    pub fn has_collectable(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
-        self.collectables.get_amount(item_utf16, e) > 0
+    pub fn get_collectable_pair(&mut self, item_utf16: &'static [u16], e: Option<&Env>) -> Option<Pair<i32>> {
+        let entry = self.collectables.entry(item_utf16).or_insert_with(|| {
+            let mut watcher = Watcher::new();
+            if let Some(Env { mem, pd, .. }) = e {
+                if let Some((_, amount)) = find_collectable(item_utf16, mem, pd) {
+                    watcher.update_infallible(amount);
+                }
+            }
+            CollectableWatcher {
+                watcher,
+                interested: true,
+            }
+        });
+        entry.interested = true;
+        entry.watcher.pair
     }
 
     pub fn get_bool_pair(&mut self, key: &str) -> Option<Pair<bool>> {
@@ -337,7 +286,7 @@ impl Store {
         #[cfg(feature = "split-index")]
         self.split_index.update(env);
         self.tools.update_validity(env);
-        self.collectables.update_validity(env);
+        self.collectables.retain(|_, v| v.interested);
         #[cfg(debug_assertions)]
         self.log_collectable_changes(env);
         for v in self.bools.values_mut() {
@@ -353,6 +302,15 @@ impl Store {
         for v in self.strings.values_mut() {
             if v.update(env) {
                 v.interested = false;
+            }
+        }
+        for (item, v) in self.collectables.iter_mut() {
+            if let Some(Env { mem, pd, .. }) = env {
+                if let Some((_, amount)) = find_collectable(item, mem, pd) {
+                    if v.watcher.update_infallible(amount).changed() {
+                        v.interested = false;
+                    }
+                }
             }
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -109,17 +109,15 @@ impl ToolCache {
     }
 }
 
+// Plain current-value cache, shaped like ToolCache - only for "currently own > 0" style checks.
+// Do NOT add increase/delta ("just picked up") tracking here: a single slot keyed only by item
+// name can't distinguish two separate occurrences of the same item-based Split later in a run
+// (see get_memory_locket_amount in silksong_memory.rs for that instead, routed through
+// Store::get_i32_pair_bang like OnObtainMaskShard).
 pub struct CollectableCache {
     version: Option<i32>,
-    // The item name this cache's amount/prev_amount history belongs to. Only changes when the
-    // caller queries a different item - a Collectables version bump does NOT clear this, so
-    // history survives across re-scans (see `stale`).
     item: &'static [u16],
-    // Set on a Collectables version bump (or construction): the cached index `i` may no longer
-    // be valid and must be re-derived via a full find_collectable scan before it's trusted again.
-    stale: bool,
     i: i32,
-    prev_amount: i32,
     amount: i32,
 }
 
@@ -128,9 +126,7 @@ impl CollectableCache {
         CollectableCache {
             version: None,
             item: &[],
-            stale: true,
             i: -1,
-            prev_amount: 0,
             amount: 0,
         }
     }
@@ -139,13 +135,13 @@ impl CollectableCache {
         match e {
             None => {
                 self.version = None;
-                self.stale = true;
+                self.item = &[]
             }
             Some(Env { pd, mem, .. }) => {
                 let new = get_collectables_version(mem, pd);
                 if self.version != new {
                     self.version = new;
-                    self.stale = true;
+                    self.item = &[]
                 }
             }
         }
@@ -157,21 +153,12 @@ impl CollectableCache {
         }
     }
 
-    /// Returns the current amount owned for `item_utf16`. Also updates the previous-amount
-    /// history used by `increased`, so calling this directly instead of through `increased`
-    /// still keeps that history correct.
     pub fn get_amount(&mut self, item_utf16: &'static [u16], e: &Env) -> i32 {
         self.update_version(Some(e));
-        let item_switched = self.item != item_utf16;
-        self.prev_amount = self.amount;
-        if item_switched {
-            self.item = item_utf16;
-            self.stale = true;
-        }
         if self.version.is_none() {
-            self.i = -1;
-            self.amount = 0;
-        } else if self.stale {
+            return 0;
+        }
+        if self.item != item_utf16 {
             if let Some((i, amount)) = find_collectable(item_utf16, e.mem, e.pd) {
                 self.i = i;
                 self.amount = amount;
@@ -179,38 +166,13 @@ impl CollectableCache {
                 self.i = -1;
                 self.amount = 0;
             }
-            self.stale = false;
+            self.item = item_utf16
         } else if !self.i.is_negative() {
             if let Some(amount) = read_collectable(self.i, e.mem, e.pd) {
                 self.amount = amount;
             }
         }
-        if item_switched {
-            // No meaningful history when comparing against a different item's amount.
-            self.prev_amount = self.amount;
-        }
-        #[cfg(debug_assertions)]
-        if self.amount != self.prev_amount {
-            let name = String::from_utf16_lossy(item_utf16);
-            let verb = if self.amount > self.prev_amount {
-                "gained"
-            } else {
-                "lost"
-            };
-            asr::print_message(&format!(
-                "Collectable \"{}\" {}: {} -> {}",
-                name, verb, self.prev_amount, self.amount
-            ));
-        }
         self.amount
-    }
-
-    /// True on the tick the amount owned for `item_utf16` goes up (e.g. picking up a
-    /// Collectable), false otherwise - mirrors `Pair::increased()` for a value that isn't
-    /// otherwise tracked via `Store`'s generic `i32s` watcher map.
-    pub fn increased(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
-        self.get_amount(item_utf16, e);
-        self.amount > self.prev_amount
     }
 }
 
@@ -316,10 +278,6 @@ impl Store {
 
     pub fn has_collectable(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
         self.collectables.get_amount(item_utf16, e) > 0
-    }
-
-    pub fn collectable_increased(&mut self, item_utf16: &'static [u16], e: &Env) -> bool {
-        self.collectables.increased(item_utf16, e)
     }
 
     pub fn get_bool_pair(&mut self, key: &str) -> Option<Pair<bool>> {


### PR DESCRIPTION
Hi Alex (or whoever sees my pr),

With me learning hundo, I really wanted to add inventory update splits, so I decided to take the time to create a system for generic inventory updates. Yes I used a lot of AI but I was very thorough with ensuring that the AI produced actual good code with a lot of testing (with asr-debugger and the likes) along with manual code review.

Even if my PR doesn't get approved, I would love it if you maybe built off what I designed to get inventory updates into the autosplitter. I'm always open to chat on discord @bimmyboi123, especially if you find bugs in my code or you find something doesn't work on the autosplitter. I've attached some documentation below on my changes (yes AI wrote it because it's lowkey fire at writing this stuff).

# Collectable "Obtain" splits

This explains the net change on `add-OnObtainMemoryLocket` versus `master`: three new
`OnObtain*` splits (Memory Locket, Cogheart Piece, Craftmetal) for the Collectables
inventory, and a generic detection system backing them so new items don't need a
dedicated function each.

## What changed

**`src/silksong_memory.rs`**

- Added two pointers, `collectables_version` and `collectables_entries`
  (`_instance.playerData.Collectables.RuntimeData._version` / `._entries`), alongside the
  existing `tools_version` / `tools_entries`.
- Added `find_collectable(item_utf16, mem, pd) -> Option<(i32, i32)>`: linear-scans the
  Collectables entries for a UTF-16 key match, returns `(index, amount)`. Generic over any
  item name.
- Added `scan_all_collectables` (debug-only): dumps every Collectables entry's name + amount.

**`src/store.rs`**

- Added `CollectableWatcher { watcher: Watcher<i32>, interested: bool }` and
  `Store.collectables: BTreeMap<&'static [u16], CollectableWatcher>` — one `Watcher<i32>`
  per item currently being watched, keyed directly by the item's UTF-16 name (a `&[u16]`
  slice is `Ord`, so no separate string key is needed).
- Added `Store::get_collectable_pair(item_utf16, e) -> Option<Pair<i32>>`: lazily
  inserts/seeds a watcher for that item, marks it `interested` for this tick, and returns
  its `Pair<i32>` (previous vs. current amount).
- `update_all` gained two loops mirroring the existing `bools`/`i32s`/`strings` handling:
  prune any collectable watcher not marked `interested` since last tick, then re-scan every
  remaining one via `find_collectable` and feed the amount into its `Watcher` — that's what
  makes `Pair::increased()` meaningful.
- Added a debug-only `log_collectable_changes`, which logs every Collectables amount change
  via `asr::print_message`, independent of any split, for diagnosing memory layout issues.

**`src/splits.rs`**

- Added three `Split` variants: `OnObtainMemoryLocket`, `OnObtainCogheartPiece`,
  `OnObtainCraftmetal`.
- Added `obtained_collectable(store, item_utf16, e) -> bool`, wrapping
  `get_collectable_pair(...).is_some_and(|p| p.increased())`.
- Added `on_obtain_item_splits`, a new dispatcher matching the three variants above to
  `obtained_collectable` calls with `utf16!(...)` item-name literals. It's spliced into
  `splits()` ahead of `continuous_splits`, because item-get popups can pause the game for a
  tick and would otherwise hide the amount change from the normal game-state-gated path.

## Impact on the rest of the repo

- **`Store`'s public surface grew by one method**, `get_collectable_pair`. Nothing existing
  was removed or changed shape.
- **`splits()`'s dispatch order changed**: `on_obtain_item_splits` now runs first, before
  `continuous_splits`. It returns `None` for every split except the three new ones, so this
  is a no-op for all existing splits.
- **`splits.json` needs regenerating** before release, since three new variants were added
  to the `Split` enum (per the repo's existing release process — not needed for review).
- **Known limitation**: detection compares this tick's amount to last tick's, once per
  frame. If a runner uses one copy of an item and picks one up within the same poll tick,
  the amount nets to no change and the split won't fire.
- Verified with `cargo check` (wasm32-unknown-unknown, dev) and `cargo build --release`:
  both clean, no warnings.

## Adding a new `OnObtain` autosplit

Two edits, both in `splits.rs`:

1. Add the enum variant with its doc comment:
   ```rust
   /// Some New Item (Obtain)
   ///
   /// Splits when obtaining a Some New Item
   OnObtainSomeNewItem,
   ```
2. Add a match arm in `on_obtain_item_splits`:
   ```rust
   Split::OnObtainSomeNewItem => should_split(obtained_collectable(store, &utf16!("Internal Item Name"), e)),
   ```

No changes needed to `silksong_memory.rs` or `store.rs` — both are already generic over
any item name.
